### PR TITLE
docs: update jelma + model-routes pages with --model flag and garda-core default

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "aspen",
+  "theme": "mint",
   "name": "Neosantara",
   "colors": {
     "primary": "#8A4300",

--- a/docs.json
+++ b/docs.json
@@ -138,6 +138,16 @@
                 ]
               },
               {
+                "group": "Jelma",
+                "pages": [
+                  "en/guides/jelma/overview",
+                  "en/guides/jelma/usage",
+                  "en/guides/jelma/reference",
+                  "en/guides/jelma/faq",
+                  "en/guides/jelma/best-practices"
+                ]
+              },
+              {
                 "group": "Capabilities",
                 "pages": [
                   "en/capability/video-generation",
@@ -713,6 +723,16 @@
                   "id/about/prompt-templates"
                 ],
                 "expanded": false
+              },
+              {
+                "group": "Jelma",
+                "pages": [
+                  "id/guides/jelma/overview",
+                  "id/guides/jelma/usage",
+                  "id/guides/jelma/reference",
+                  "id/guides/jelma/faq",
+                  "id/guides/jelma/best-practices"
+                ]
               }
             ]
           },

--- a/docs.json
+++ b/docs.json
@@ -1300,7 +1300,7 @@
   },
   "head": [
     "<link rel=\"stylesheet\" href=\"/style.css\">",
-    "<script src=\"/language-toggle.js\"></script>"
+    "<script defer src=\"/language-toggle.js\"></script>"
   ],
   "thumbnails": {
     "appearance": "dark"

--- a/docs.json
+++ b/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "mint",
+  "theme": "aspen",
   "name": "Neosantara",
   "colors": {
     "primary": "#8A4300",

--- a/docs.json
+++ b/docs.json
@@ -179,7 +179,8 @@
                   "en/coding-plan/quick-start",
                   "en/coding-plan/jelma",
                   "en/coding-plan/tool-integration",
-                  "en/coding-plan/switching-models"
+                  "en/coding-plan/switching-models",
+                  "en/coding-plan/model-routes"
                 ]
               },
               {
@@ -735,7 +736,8 @@
                   "id/coding-plan/quick-start",
                   "id/coding-plan/jelma",
                   "id/coding-plan/tool-integration",
-                  "id/coding-plan/switching-models"
+                  "id/coding-plan/switching-models",
+                  "id/coding-plan/model-routes"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -181,6 +181,13 @@
                   "en/coding-plan/tool-integration",
                   "en/coding-plan/switching-models"
                 ]
+              },
+              {
+                "group": "Learning Resources",
+                "pages": [
+                  "en/coding-plan/best-practice",
+                  "en/coding-plan/memory-mechanism"
+                ]
               }
             ]
           },
@@ -729,6 +736,13 @@
                   "id/coding-plan/jelma",
                   "id/coding-plan/tool-integration",
                   "id/coding-plan/switching-models"
+                ]
+              },
+              {
+                "group": "Sumber Belajar",
+                "pages": [
+                  "id/coding-plan/best-practice",
+                  "id/coding-plan/memory-mechanism"
                 ]
               }
             ]

--- a/docs.json
+++ b/docs.json
@@ -74,7 +74,6 @@
             "pages": [
               {
                 "group": "Getting Started",
-                "icon": "book-open",
                 "pages": [
                   "en/intro",
                   "en/about",
@@ -85,12 +84,10 @@
               },
               {
                 "group": "SDKs & APIs",
-                "icon": "code",
                 "pages": [
                   "en/sdk/index",
                   {
                     "group": "OpenResponses API",
-                    "icon": "bolt",
                     "pages": [
                       "en/sdk/responses-api/index",
                       "en/sdk/responses-api/text-generation",
@@ -104,7 +101,6 @@
                   },
                   {
                     "group": "OpenAI Compatible",
-                    "icon": "comment",
                     "pages": [
                       "en/sdk/openai-compat/index",
                       "en/sdk/openai-compat/chat-completions",
@@ -120,7 +116,6 @@
                   },
                   {
                     "group": "Anthropic Compatible",
-                    "icon": "hand",
                     "pages": [
                       "en/sdk/anthropic-compat/index",
                       "en/sdk/anthropic-compat/messages",
@@ -136,7 +131,6 @@
               },
               {
                 "group": "Core Concepts",
-                "icon": "compass",
                 "pages": [
                   "en/advanced-examples",
                   "en/error-handling",
@@ -145,7 +139,6 @@
               },
               {
                 "group": "Capabilities",
-                "icon": "grip",
                 "pages": [
                   "en/capability/video-generation",
                   "en/capability/image-generation",
@@ -167,18 +160,41 @@
             ]
           },
           {
+            "tab": "Coding Plan",
+            "icon": "terminal",
+            "pages": [
+              {
+                "group": "Coding Plan",
+                "pages": [
+                  "en/coding-plan/learning-path",
+                  "en/coding-plan/overview",
+                  "en/coding-plan/quota-and-limits",
+                  "en/coding-plan/usage-policy",
+                  "en/coding-plan/faq"
+                ]
+              },
+              {
+                "group": "Guide",
+                "pages": [
+                  "en/coding-plan/quick-start",
+                  "en/coding-plan/jelma",
+                  "en/coding-plan/tool-integration",
+                  "en/coding-plan/switching-models"
+                ]
+              }
+            ]
+          },
+          {
             "tab": "Models",
             "icon": "layer-group",
             "pages": [
               {
                 "group": "Models & Pricing",
-                "icon": "dollar-sign",
                 "expanded": false,
                 "pages": [
                   "en/models-overview",
                   {
                     "group": "Active Models",
-                    "icon": "star",
                     "expanded": false,
                     "pages": [
                       {
@@ -376,7 +392,6 @@
                   },
                   {
                     "group": "Deprecated Models",
-                    "icon": "clock",
                     "expanded": false,
                     "pages": [
                       {
@@ -438,7 +453,6 @@
             "pages": [
               {
                 "group": "Integrations",
-                "icon": "puzzle-piece",
                 "pages": [
                   "en/agent-overview",
                   "en/integrations",
@@ -447,7 +461,6 @@
                   "en/mcp",
                   {
                     "group": "Frameworks",
-                    "icon": "cube",
                     "pages": [
                       "en/langchain",
                       "en/crewai",
@@ -465,7 +478,6 @@
               },
               {
                 "group": "Tutorials",
-                "icon": "graduation-cap",
                 "pages": [
                   "en/guides/ai-coding-tools",
                   "en/capability/rag",
@@ -486,7 +498,6 @@
             "pages": [
               {
                 "group": "API Usage",
-                "icon": "book-open",
                 "pages": [
                   "en/api-introduction",
                   "en/about/billing-pricing",
@@ -497,61 +508,52 @@
               },
               {
                 "group": "Endpoints",
-                "icon": "code",
                 "openapi": "api-reference/openapi.json",
                 "pages": [
                   {
                     "group": "Responses",
-                    "icon": "bolt",
                     "pages": [
                       "POST /v1/responses"
                     ]
                   },
                   {
                     "group": "Chat",
-                    "icon": "comment",
                     "pages": [
                       "POST /v1/chat/completions"
                     ]
                   },
                   {
                     "group": "Anthropic",
-                    "icon": "hand",
                     "pages": [
                       "POST /anthropic/v1/messages"
                     ]
                   },
                   {
                     "group": "Images",
-                    "icon": "image",
                     "pages": [
                       "POST /v1/images/generations"
                     ]
                   },
                   {
                     "group": "Audio",
-                    "icon": "microphone",
                     "pages": [
                       "POST /v1/audio/transcriptions"
                     ]
                   },
                   {
                     "group": "Embeddings",
-                    "icon": "database",
                     "pages": [
                       "POST /v1/embeddings"
                     ]
                   },
                   {
                     "group": "Vision",
-                    "icon": "eye",
                     "pages": [
                       "POST /v1/ocr"
                     ]
                   },
                   {
                     "group": "Videos",
-                    "icon": "video",
                     "pages": [
                       "api-reference/videos/create",
                       "api-reference/videos/get",
@@ -560,11 +562,9 @@
                   },
                   {
                     "group": "Asynchronous",
-                    "icon": "arrows-rotate",
                     "pages": [
                       {
                         "group": "Batches",
-                        "icon": "rows",
                         "pages": [
                           "en/batches-overview",
                           "POST /v1/batches",
@@ -576,7 +576,6 @@
                       },
                       {
                         "group": "Files",
-                        "icon": "file",
                         "pages": [
                           "en/files-overview",
                           "POST /v1/files",
@@ -589,7 +588,6 @@
                       },
                       {
                         "group": "Webhooks",
-                        "icon": "link",
                         "pages": [
                           "en/webhooks-overview"
                         ]
@@ -599,7 +597,6 @@
                   },
                   {
                     "group": "Management",
-                    "icon": "gear",
                     "pages": [
                       "GET /v1/models",
                       "GET /v1/models/{modelId}",
@@ -626,7 +623,6 @@
             "pages": [
               {
                 "group": "Langkah Pertama",
-                "icon": "book-open",
                 "pages": [
                   "id/intro",
                   "id/about",
@@ -637,12 +633,10 @@
               },
               {
                 "group": "SDKs & APIs",
-                "icon": "code",
                 "pages": [
                   "id/sdk/index",
                   {
                     "group": "OpenResponses API",
-                    "icon": "bolt",
                     "pages": [
                       "id/sdk/responses-api/index",
                       "id/sdk/responses-api/text-generation",
@@ -656,7 +650,6 @@
                   },
                   {
                     "group": "OpenAI Compatible",
-                    "icon": "comment",
                     "pages": [
                       "id/sdk/openai-compat/index",
                       "id/sdk/openai-compat/chat-completions",
@@ -672,7 +665,6 @@
                   },
                   {
                     "group": "Anthropic Compatible",
-                    "icon": "hand",
                     "pages": [
                       "id/sdk/anthropic-compat/index",
                       "id/sdk/anthropic-compat/messages",
@@ -688,7 +680,6 @@
               },
               {
                 "group": "Konsep Inti",
-                "icon": "compass",
                 "pages": [
                   "id/advanced-examples",
                   "id/error-handling",
@@ -697,7 +688,6 @@
               },
               {
                 "group": "Kemampuan",
-                "icon": "grip",
                 "pages": [
                   "id/capability/video-generation",
                   "id/capability/embeddings",
@@ -719,18 +709,41 @@
             ]
           },
           {
+            "tab": "Coding Plan",
+            "icon": "terminal",
+            "pages": [
+              {
+                "group": "Coding Plan",
+                "pages": [
+                  "id/coding-plan/learning-path",
+                  "id/coding-plan/overview",
+                  "id/coding-plan/quota-and-limits",
+                  "id/coding-plan/usage-policy",
+                  "id/coding-plan/faq"
+                ]
+              },
+              {
+                "group": "Panduan",
+                "pages": [
+                  "id/coding-plan/quick-start",
+                  "id/coding-plan/jelma",
+                  "id/coding-plan/tool-integration",
+                  "id/coding-plan/switching-models"
+                ]
+              }
+            ]
+          },
+          {
             "tab": "Model",
             "icon": "layer-group",
             "pages": [
               {
                 "group": "Model & Harga",
-                "icon": "dollar-sign",
                 "expanded": false,
                 "pages": [
                   "id/models-overview",
                   {
                     "group": "Model Aktif",
-                    "icon": "star",
                     "expanded": false,
                     "pages": [
                       {
@@ -928,7 +941,6 @@
                   },
                   {
                     "group": "Model Deprecated",
-                    "icon": "clock",
                     "expanded": false,
                     "pages": [
                       {
@@ -990,7 +1002,6 @@
             "pages": [
               {
                 "group": "Integrasi",
-                "icon": "puzzle-piece",
                 "pages": [
                   "id/agent-overview",
                   "id/integrations",
@@ -1002,7 +1013,6 @@
                   "id/mcp",
                   {
                     "group": "Framework",
-                    "icon": "cube",
                     "pages": [
                       "id/langchain",
                       "id/crewai",
@@ -1020,7 +1030,6 @@
               },
               {
                 "group": "Tutorial",
-                "icon": "graduation-cap",
                 "pages": [
                   "id/guides/ai-coding-tools",
                   "id/capability/rag",
@@ -1041,7 +1050,6 @@
             "pages": [
               {
                 "group": "Penggunaan API",
-                "icon": "book-open",
                 "pages": [
                   "id/api-introduction",
                   "id/about/billing-pricing",
@@ -1052,61 +1060,52 @@
               },
               {
                 "group": "Referensi API",
-                "icon": "code",
                 "openapi": "api-reference/openapi.json",
                 "pages": [
                   {
                     "group": "Responses",
-                    "icon": "bolt",
                     "pages": [
                       "POST /v1/responses"
                     ]
                   },
                   {
                     "group": "Chat",
-                    "icon": "comment",
                     "pages": [
                       "POST /v1/chat/completions"
                     ]
                   },
                   {
                     "group": "Anthropic",
-                    "icon": "hand",
                     "pages": [
                       "POST /anthropic/v1/messages"
                     ]
                   },
                   {
                     "group": "Images",
-                    "icon": "image",
                     "pages": [
                       "POST /v1/images/generations"
                     ]
                   },
                   {
                     "group": "Audio",
-                    "icon": "microphone",
                     "pages": [
                       "POST /v1/audio/transcriptions"
                     ]
                   },
                   {
                     "group": "Embeddings",
-                    "icon": "database",
                     "pages": [
                       "POST /v1/embeddings"
                     ]
                   },
                   {
                     "group": "Vision",
-                    "icon": "eye",
                     "pages": [
                       "POST /v1/ocr"
                     ]
                   },
                   {
                     "group": "Videos",
-                    "icon": "video",
                     "pages": [
                       "api-reference/videos/create",
                       "api-reference/videos/get",
@@ -1115,11 +1114,9 @@
                   },
                   {
                     "group": "Asynchronous",
-                    "icon": "arrows-rotate",
                     "pages": [
                       {
                         "group": "Batch",
-                        "icon": "rows",
                         "pages": [
                           "id/batches-overview",
                           "POST /v1/batches",
@@ -1131,7 +1128,6 @@
                       },
                       {
                         "group": "File",
-                        "icon": "file",
                         "pages": [
                           "id/files-overview",
                           "POST /v1/files",
@@ -1144,7 +1140,6 @@
                       },
                       {
                         "group": "Webhook",
-                        "icon": "link",
                         "pages": [
                           "id/webhooks-overview"
                         ]
@@ -1154,7 +1149,6 @@
                   },
                   {
                     "group": "Manajemen",
-                    "icon": "gear",
                     "pages": [
                       "GET /v1/models",
                       "GET /v1/models/{modelId}",

--- a/docs/superpowers/plans/2026-07-03-coding-plan-learning-path-and-quota.md
+++ b/docs/superpowers/plans/2026-07-03-coding-plan-learning-path-and-quota.md
@@ -1,0 +1,588 @@
+# Coding Plan Learning Path & Quota Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Learning Path hub and a canonical Quota & Limits page to the Coding Plan docs (EN + ID), register them in `docs.json`, and trim duplicated quota content from existing pages.
+
+**Architecture:** Two new MDX pages per language. Quota & Limits becomes the single source of truth for prompt-based quota, windows, tier pricing, and load multipliers; existing pages replace their duplicated blocks with links to it. Learning Path is a pure navigation hub (start-here `<Steps>` spine + shortcut `<CardGroup>`).
+
+**Tech Stack:** Mintlify MDX, `docs.json` navigation.
+
+## Global Constraints
+
+- ID content uses "Kamu" (capital K) as the second-person pronoun; never "Anda".
+- Internal links are root-relative, e.g. `/en/coding-plan/quota-and-limits`.
+- Every MDX file has `title` + `description` frontmatter.
+- Escape `<` / `<=` in tables/text with backticks or unicode (`≤`).
+- No new model identifiers. Only reuse: `claude-4.5-sonnet`, `claude-4.5-opus`, `gemini-3-flash`, `glm-4.7-flash`, `deepseek-r1`, `qwen3-32b`.
+- Canonical tier/pricing table lives ONLY in Quota & Limits; other pages link to it.
+- Git author identity for commits: `ErRickow <er_rickow@neosantara.xyz>` (pass inline via `git -c user.name=... -c user.email=...`, do not modify config). Repo is in detached HEAD.
+
+---
+
+### Task 1: Create the canonical Quota & Limits page (EN)
+
+Build this first — everything else links to it.
+
+**Files:**
+- Create: `en/coding-plan/quota-and-limits.mdx`
+
+**Interfaces:**
+- Produces: page at route `/en/coding-plan/quota-and-limits` (linked by learning-path, overview, switching-models, quick-start, faq).
+
+- [ ] **Step 1: Create the file with full content**
+
+```mdx
+---
+title: "Quota & Limits"
+description: "How the Neosantara Coding Plan quota works — prompts, 5-hour and weekly windows, tier limits, and load-based model multipliers."
+---
+
+This is the canonical reference for how quota is measured and consumed on the [Coding Plan](/en/coding-plan/overview).
+
+## What Counts as 1 Prompt
+
+Quota is **prompt-based, not token-based**. One prompt = **one user turn** in your coding tool — no matter how many model calls the agent makes under the hood.
+
+<Info>
+  A single "fix this bug" turn may trigger ~15–20 model calls internally (reasoning steps, tool calls, file reads). That entire turn still counts as **1 prompt**.
+</Info>
+
+**Worked example:** You ask your agent to *"refactor this module and update the tests."* The agent reads 6 files, runs the test suite twice, and makes 18 model calls to complete the task. Your quota decreases by **1 prompt** (times the model multiplier — see below).
+
+## Quota Windows
+
+| Window | Behavior |
+|--------|----------|
+| **5-hour rolling** | Resets automatically 5 hours after use begins. |
+| **Weekly** | Resets 7 days from your subscription start. |
+
+- **No overage.** When a window's quota is exhausted, requests are hard-stopped until it resets.
+- **No balance deduction.** The Coding Plan never charges your PAYG balance.
+
+## Plan Tiers
+
+| Tier | 5-Hour Limit | Weekly Limit | Price |
+|------|--------------|--------------|-------|
+| Coding Hemat | ~80 prompts | ~400 prompts | Rp 149.000/mo |
+| Coding Reguler | ~400 prompts | ~2.000 prompts | Rp 499.000/mo |
+| Coding Eksklusif | ~1.600 prompts | ~8.000 prompts | Rp 1.290.000/mo |
+
+<Info>
+  Actual available usage varies with project complexity and model choice.
+</Info>
+
+## Load-Based Model Multipliers
+
+Each prompt consumes quota equal to its model's multiplier. Flagship models cost more when the upstream is **under load**. Load is detected **dynamically per model** from its live capacity-error rate over a rolling window — it is **not** a fixed time-of-day schedule.
+
+| Condition | Flagship models | Mid-tier models | Lightweight models |
+|-----------|-----------------|-----------------|--------------------|
+| Normal | 2× | 2× | 1× |
+| Under load | 3× | 2× | 1× |
+
+<Note>
+  Only flagship-band models switch between 2× and 3×. Mid-tier stays at 2× and lightweight stays at 1× regardless of load. "Under load" is derived from each model's live upstream capacity, not a wall-clock window.
+</Note>
+
+## Tips to Conserve Quota
+
+<Tip>
+  Use lightweight models (`gemini-3-flash`, `glm-4.7-flash`) for routine tasks — they stay at 1×. Reserve flagship models (`claude-4.5-sonnet`, `claude-4.5-opus`) for complex reasoning and large refactors.
+</Tip>
+
+- Batch related changes into a single turn where practical — fewer turns, fewer prompts.
+- Switch models per task instead of running everything on a flagship. See [Switching Models](/en/coding-plan/switching-models).
+
+## Related
+
+- [Switching Models](/en/coding-plan/switching-models) — pick the right model per task.
+- [Usage Policy](/en/coding-plan/usage-policy) — rate-limit enforcement and fair use.
+```
+
+- [ ] **Step 2: Verify frontmatter and no forbidden model names**
+
+Run: `grep -nE "claude-opus-4-6|gemini-3-pro|neosantara-gen" en/coding-plan/quota-and-limits.mdx`
+Expected: no output (no unlisted/new model IDs).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" add en/coding-plan/quota-and-limits.mdx && \
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" commit -m "docs: add canonical Coding Plan Quota & Limits page (EN)"
+```
+
+---
+
+### Task 2: Create the canonical Quota & Limits page (ID)
+
+**Files:**
+- Create: `id/coding-plan/quota-and-limits.mdx`
+
+**Interfaces:**
+- Produces: page at route `/id/coding-plan/quota-and-limits`.
+
+- [ ] **Step 1: Create the file with full content**
+
+```mdx
+---
+title: "Kuota & Limit"
+description: "Cara kerja kuota Neosantara Coding Plan — prompt, jendela 5 jam dan mingguan, limit tier, dan multiplier model berbasis beban."
+---
+
+Ini referensi kanonik cara kuota dihitung dan dipakai di [Coding Plan](/id/coding-plan/overview).
+
+## Apa yang Dihitung sebagai 1 Prompt
+
+Kuota **berbasis prompt, bukan token**. Satu prompt = **satu giliran user** di coding tool — berapa pun panggilan model yang dilakukan agent di balik layar.
+
+<Info>
+  Satu giliran "perbaiki bug ini" bisa memicu ~15–20 panggilan model secara internal (langkah reasoning, tool call, baca file). Seluruh giliran itu tetap dihitung **1 prompt**.
+</Info>
+
+**Contoh nyata:** Kamu minta agent *"refactor modul ini dan update test-nya."* Agent membaca 6 file, menjalankan test suite dua kali, dan melakukan 18 panggilan model. Kuotamu berkurang **1 prompt** (dikali multiplier model — lihat di bawah).
+
+## Jendela Kuota
+
+| Jendela | Perilaku |
+|---------|----------|
+| **Rolling 5 jam** | Reset otomatis 5 jam setelah pemakaian dimulai. |
+| **Mingguan** | Reset 7 hari sejak awal langganan. |
+
+- **Tanpa overage.** Saat kuota sebuah jendela habis, request di-hard-stop sampai reset.
+- **Tanpa potongan saldo.** Coding Plan tidak pernah memotong saldo PAYG-mu.
+
+## Tier Paket
+
+| Tier | Limit 5 Jam | Limit Mingguan | Harga |
+|------|-------------|----------------|-------|
+| Coding Hemat | ~80 prompt | ~400 prompt | Rp 149.000/bln |
+| Coding Reguler | ~400 prompt | ~2.000 prompt | Rp 499.000/bln |
+| Coding Eksklusif | ~1.600 prompt | ~8.000 prompt | Rp 1.290.000/bln |
+
+<Info>
+  Penggunaan aktual bervariasi tergantung kompleksitas proyek dan pilihan model.
+</Info>
+
+## Multiplier Model Berbasis Beban
+
+Setiap prompt memakai kuota sebesar multiplier model-nya. Model flagship makan lebih banyak saat upstream sedang **under load**. Beban dideteksi **dinamis per model** dari live capacity-error rate-nya pada rolling window — **bukan** jadwal jam tetap.
+
+| Kondisi | Model flagship | Model mid | Model ringan |
+|---------|----------------|-----------|--------------|
+| Normal | 2× | 2× | 1× |
+| Under load | 3× | 2× | 1× |
+
+<Note>
+  Hanya model flagship yang berpindah antara 2× dan 3×. Model mid tetap 2× dan model ringan tetap 1× berapa pun bebannya. "Under load" ditentukan dari kapasitas upstream tiap model secara live, bukan jendela jam.
+</Note>
+
+## Tips Hemat Kuota
+
+<Tip>
+  Pakai model ringan (`gemini-3-flash`, `glm-4.7-flash`) untuk tugas rutin — tetap 1×. Simpan model flagship (`claude-4.5-sonnet`, `claude-4.5-opus`) untuk reasoning kompleks dan refactor besar.
+</Tip>
+
+- Gabungkan perubahan terkait dalam satu giliran bila memungkinkan — lebih sedikit giliran, lebih sedikit prompt.
+- Ganti model per tugas alih-alih menjalankan semuanya di flagship. Lihat [Ganti Model](/id/coding-plan/switching-models).
+
+## Terkait
+
+- [Ganti Model](/id/coding-plan/switching-models) — pilih model yang tepat per tugas.
+- [Usage Policy](/id/coding-plan/usage-policy) — penegakan rate-limit dan fair use.
+```
+
+- [ ] **Step 2: Verify "Kamu" convention (no "Anda")**
+
+Run: `grep -nw "Anda" id/coding-plan/quota-and-limits.mdx`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" add id/coding-plan/quota-and-limits.mdx && \
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" commit -m "docs: add canonical Coding Plan Quota & Limits page (ID)"
+```
+
+---
+
+### Task 3: Create the Learning Path hub (EN)
+
+**Files:**
+- Create: `en/coding-plan/learning-path.mdx`
+
+**Interfaces:**
+- Consumes: links to `/en/coding-plan/{quick-start,jelma,tool-integration,switching-models,quota-and-limits,usage-policy}`.
+- Produces: page at route `/en/coding-plan/learning-path`.
+
+- [ ] **Step 1: Create the file with full content**
+
+```mdx
+---
+title: "Learning Path"
+description: "Start here — the fastest route through the Neosantara Coding Plan, from subscribing to optimizing quota."
+---
+
+New to the Coding Plan? Follow the path below. Already know what you need? Jump ahead with the shortcut cards.
+
+## Start Here
+
+<Steps>
+  <Step title="Subscribe & get a coding key">
+    Pick a tier and create a `nsk_code_*` key. See the [Overview](/en/coding-plan/overview) for how the plan works.
+  </Step>
+  <Step title="Connect a tool">
+    Wire up your coding agent — [Tool Integration](/en/coding-plan/tool-integration) for Claude Code, Cline, Continue, OpenCode, or Cursor. Prefer zero setup? Use [Jelma](/en/coding-plan/jelma).
+  </Step>
+  <Step title="Send your first prompt">
+    Follow the [Quick Start](/en/coding-plan/quick-start) to verify your setup and start coding.
+  </Step>
+  <Step title="Understand your quota">
+    Learn how prompts, windows, and multipliers work in [Quota & Limits](/en/coding-plan/quota-and-limits).
+  </Step>
+  <Step title="Optimize">
+    Switch models per task to conserve quota — see [Switching Models](/en/coding-plan/switching-models).
+  </Step>
+</Steps>
+
+## Shortcuts
+
+<CardGroup cols={2}>
+  <Card title="Zero setup" href="/en/coding-plan/jelma">
+    Launch an agent with no config using Jelma.
+  </Card>
+  <Card title="I use Claude Code / Cline / Cursor" href="/en/coding-plan/tool-integration">
+    Manual configuration for supported tools.
+  </Card>
+  <Card title="Minimize quota burn" href="/en/coding-plan/quota-and-limits">
+    Quota rules plus model-switching strategy.
+  </Card>
+  <Card title="Rules & fair use" href="/en/coding-plan/usage-policy">
+    What's allowed and how limits are enforced.
+  </Card>
+</CardGroup>
+```
+
+- [ ] **Step 2: Verify linked pages exist**
+
+Run: `for p in overview tool-integration jelma quick-start quota-and-limits switching-models usage-policy; do test -f en/coding-plan/$p.mdx || echo "MISSING: $p"; done`
+Expected: no "MISSING" output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" add en/coding-plan/learning-path.mdx && \
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" commit -m "docs: add Coding Plan Learning Path hub (EN)"
+```
+
+---
+
+### Task 4: Create the Learning Path hub (ID)
+
+**Files:**
+- Create: `id/coding-plan/learning-path.mdx`
+
+**Interfaces:**
+- Produces: page at route `/id/coding-plan/learning-path`.
+
+- [ ] **Step 1: Create the file with full content**
+
+```mdx
+---
+title: "Learning Path"
+description: "Mulai di sini — rute tercepat menjelajahi Neosantara Coding Plan, dari langganan hingga mengoptimalkan kuota."
+---
+
+Baru di Coding Plan? Ikuti alur di bawah. Sudah tahu yang Kamu butuhkan? Lompat lewat kartu pintasan.
+
+## Mulai di Sini
+
+<Steps>
+  <Step title="Langganan & dapatkan coding key">
+    Pilih tier dan buat key `nsk_code_*`. Lihat [Overview](/id/coding-plan/overview) untuk cara kerja paket.
+  </Step>
+  <Step title="Hubungkan tool">
+    Sambungkan coding agent-mu — [Tool Integration](/id/coding-plan/tool-integration) untuk Claude Code, Cline, Continue, OpenCode, atau Cursor. Mau tanpa setup? Pakai [Jelma](/id/coding-plan/jelma).
+  </Step>
+  <Step title="Kirim prompt pertama">
+    Ikuti [Mulai Cepat](/id/coding-plan/quick-start) untuk verifikasi setup dan mulai coding.
+  </Step>
+  <Step title="Pahami kuotamu">
+    Pelajari cara kerja prompt, jendela, dan multiplier di [Kuota & Limit](/id/coding-plan/quota-and-limits).
+  </Step>
+  <Step title="Optimalkan">
+    Ganti model per tugas untuk hemat kuota — lihat [Ganti Model](/id/coding-plan/switching-models).
+  </Step>
+</Steps>
+
+## Pintasan
+
+<CardGroup cols={2}>
+  <Card title="Tanpa setup" href="/id/coding-plan/jelma">
+    Jalankan agent tanpa konfigurasi pakai Jelma.
+  </Card>
+  <Card title="Saya pakai Claude Code / Cline / Cursor" href="/id/coding-plan/tool-integration">
+    Konfigurasi manual untuk tool yang didukung.
+  </Card>
+  <Card title="Hemat kuota" href="/id/coding-plan/quota-and-limits">
+    Aturan kuota plus strategi ganti model.
+  </Card>
+  <Card title="Aturan & fair use" href="/id/coding-plan/usage-policy">
+    Apa yang diizinkan dan cara limit ditegakkan.
+  </Card>
+</CardGroup>
+```
+
+- [ ] **Step 2: Verify "Kamu" convention and linked pages**
+
+Run: `grep -nw "Anda" id/coding-plan/learning-path.mdx; for p in overview tool-integration jelma quick-start quota-and-limits switching-models usage-policy; do test -f id/coding-plan/$p.mdx || echo "MISSING: $p"; done`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" add id/coding-plan/learning-path.mdx && \
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" commit -m "docs: add Coding Plan Learning Path hub (ID)"
+```
+
+---
+
+### Task 5: Register new pages in docs.json
+
+**Files:**
+- Modify: `docs.json` (EN "Coding Plan" tab group + ID "Coding Plan" tab group)
+
+**Interfaces:**
+- Consumes: routes produced by Tasks 1–4.
+
+- [ ] **Step 1: Update the EN "Coding Plan" group**
+
+Find the EN block:
+```json
+              {
+                "group": "Coding Plan",
+                "pages": [
+                  "en/coding-plan/overview",
+                  "en/coding-plan/usage-policy",
+                  "en/coding-plan/faq"
+                ]
+              },
+```
+Replace with:
+```json
+              {
+                "group": "Coding Plan",
+                "pages": [
+                  "en/coding-plan/learning-path",
+                  "en/coding-plan/overview",
+                  "en/coding-plan/quota-and-limits",
+                  "en/coding-plan/usage-policy",
+                  "en/coding-plan/faq"
+                ]
+              },
+```
+
+- [ ] **Step 2: Update the ID "Coding Plan" group**
+
+Find the ID block:
+```json
+              {
+                "group": "Coding Plan",
+                "pages": [
+                  "id/coding-plan/overview",
+                  "id/coding-plan/usage-policy",
+                  "id/coding-plan/faq"
+                ]
+              },
+```
+Replace with:
+```json
+              {
+                "group": "Coding Plan",
+                "pages": [
+                  "id/coding-plan/learning-path",
+                  "id/coding-plan/overview",
+                  "id/coding-plan/quota-and-limits",
+                  "id/coding-plan/usage-policy",
+                  "id/coding-plan/faq"
+                ]
+              },
+```
+
+- [ ] **Step 3: Verify docs.json is valid JSON**
+
+Run: `python3 -c "import json;json.load(open('docs.json'));print('valid')"`
+Expected: `valid`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" add docs.json && \
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" commit -m "docs: register Coding Plan learning-path & quota pages in nav"
+```
+
+---
+
+### Task 6: Trim duplicated quota content in existing pages (EN)
+
+**Files:**
+- Modify: `en/coding-plan/overview.mdx`
+- Modify: `en/coding-plan/switching-models.mdx`
+- Modify: `en/coding-plan/quick-start.mdx`
+- Modify: `en/coding-plan/faq.mdx`
+
+- [ ] **Step 1: Trim overview.mdx — replace the `## Quota & Limits` + `## Plans` sections**
+
+Replace these two sections (the `## Quota & Limits` bullet list and the `## Plans` table + its `<Info>`):
+```mdx
+## Quota & Limits
+
+- Quota is prompt-based (not token-based).
+- 1 prompt = 1 user turn, regardless of how many model calls the agent makes internally.
+- When a flagship model is under load, its quota multiplier rises to 3× (from 2× normal). Use lighter models for routine tasks to conserve quota.
+- When quota runs out, requests are blocked until the next window resets — no balance deduction, no overage.
+
+## Plans
+
+| Tier | 5-Hour Limit | Weekly Limit | Price |
+|------|--------------|--------------|-------|
+| Coding Hemat | ~80 prompts | ~400 prompts | Rp 149.000/mo |
+| Coding Reguler | ~400 prompts | ~2.000 prompts | Rp 499.000/mo |
+| Coding Eksklusif | ~1.600 prompts | ~8.000 prompts | Rp 1.290.000/mo |
+
+<Info>
+  Actual available usage may vary depending on project complexity and model choice.
+</Info>
+```
+with:
+```mdx
+## Quota & Limits
+
+Quota is prompt-based: **1 prompt = 1 user turn**, regardless of how many model calls the agent makes internally. There is no overage — when a window's quota runs out, requests are blocked until it resets.
+
+See [Quota & Limits](/en/coding-plan/quota-and-limits) for the full tier pricing table, 5-hour/weekly windows, and load-based model multipliers.
+```
+
+- [ ] **Step 2: Trim switching-models.mdx — replace the `## Load-Based Quota Multipliers` section**
+
+Replace the entire `## Load-Based Quota Multipliers` section (heading, table, and `<Note>`) with:
+```mdx
+## Load-Based Quota Multipliers
+
+Model multipliers (1× lightweight, 2× mid/flagship, up to 3× for flagship under load) determine how much quota each prompt costs. See [Quota & Limits](/en/coding-plan/quota-and-limits#load-based-model-multipliers) for the full breakdown.
+```
+
+- [ ] **Step 3: Trim quick-start.mdx — replace the multiplier restatement in `## Tips for Efficient Quota Usage`**
+
+In the `<Tip>` under `## Tips for Efficient Quota Usage`, replace:
+```mdx
+<Tip>
+  **Use lightweight models for routine tasks.** Models like `gemini-3-flash` or `glm-4.7-flash` consume 1× quota. Premium models like `claude-4.5-opus` consume up to 3× when the model is under load. Switch to premium only for complex reasoning tasks.
+</Tip>
+```
+with:
+```mdx
+<Tip>
+  **Use lightweight models for routine tasks.** `gemini-3-flash` and `glm-4.7-flash` consume 1× quota; flagship models cost more (up to 3× under load). See [Quota & Limits](/en/coding-plan/quota-and-limits) for the full multiplier table.
+</Tip>
+```
+
+- [ ] **Step 4: Trim faq.mdx — link the quota accordion instead of restating numbers**
+
+In the accordion titled "How much quota does the plan provide?", replace its body:
+```mdx
+    Each plan tier has a 5-hour rolling limit and a weekly limit:
+    - **Coding Hemat**: ~80 prompts / 5 hours, ~400 / week
+    - **Coding Reguler**: ~400 prompts / 5 hours, ~2,000 / week
+    - **Coding Eksklusif**: ~1,600 prompts / 5 hours, ~8,000 / week
+
+    In token terms, each prompt typically triggers 15–20 model calls, giving a total monthly allowance far exceeding what you'd get at standard API pricing.
+```
+with:
+```mdx
+    Each tier has a 5-hour rolling limit and a weekly limit. See the full table in [Quota & Limits](/en/coding-plan/quota-and-limits#plan-tiers). Each prompt typically triggers 15–20 model calls, so the effective monthly allowance far exceeds standard API pricing.
+```
+
+- [ ] **Step 5: Verify links resolve and commit**
+
+Run: `test -f en/coding-plan/quota-and-limits.mdx && echo ok`
+Expected: `ok`
+```bash
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" add en/coding-plan/overview.mdx en/coding-plan/switching-models.mdx en/coding-plan/quick-start.mdx en/coding-plan/faq.mdx && \
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" commit -m "docs: point EN Coding Plan pages to canonical Quota & Limits"
+```
+
+---
+
+### Task 7: Trim duplicated quota content in existing pages (ID)
+
+**Files:**
+- Modify: `id/coding-plan/overview.mdx`
+- Modify: `id/coding-plan/switching-models.mdx`
+- Modify: `id/coding-plan/quick-start.mdx`
+- Modify: `id/coding-plan/faq.mdx`
+
+- [ ] **Step 1: Trim overview.mdx — replace the `## Kuota & Limit` + `## Paket` sections**
+
+Replace the `## Kuota & Limit` bullet list and the `## Paket` table + its `<Info>` with:
+```mdx
+## Kuota & Limit
+
+Kuota berbasis prompt: **1 prompt = 1 giliran user**, berapa pun panggilan model yang dilakukan agent secara internal. Tidak ada overage — saat kuota sebuah jendela habis, request diblokir sampai reset.
+
+Lihat [Kuota & Limit](/id/coding-plan/quota-and-limits) untuk tabel harga tier lengkap, jendela 5 jam/mingguan, dan multiplier model berbasis beban.
+```
+
+- [ ] **Step 2: Trim switching-models.mdx — replace the `## Multiplier Kuota Berbasis Beban` section**
+
+Replace the entire `## Multiplier Kuota Berbasis Beban` section (heading, table, and `<Note>`) with:
+```mdx
+## Multiplier Kuota Berbasis Beban
+
+Multiplier model (1× ringan, 2× mid/flagship, hingga 3× untuk flagship under load) menentukan berapa kuota yang dipakai tiap prompt. Lihat [Kuota & Limit](/id/coding-plan/quota-and-limits#multiplier-model-berbasis-beban) untuk rinciannya.
+```
+
+- [ ] **Step 3: Verify "Kamu" convention across modified ID files**
+
+Run: `grep -nw "Anda" id/coding-plan/overview.mdx id/coding-plan/switching-models.mdx`
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" add id/coding-plan/overview.mdx id/coding-plan/switching-models.mdx && \
+git -c user.name="ErRickow" -c user.email="er_rickow@neosantara.xyz" commit -m "docs: point ID Coding Plan pages to canonical Kuota & Limit"
+```
+
+<Note>
+Note: the ID quick-start.mdx and faq.mdx do not contain the same standalone quota-multiplier duplication as EN (verify during implementation). If equivalent duplicated blocks exist, apply the same pointer treatment as Task 6 Steps 3–4 using ID routes; otherwise skip and note it.
+</Note>
+
+---
+
+### Task 8: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: docs.json valid**
+
+Run: `python3 -c "import json;json.load(open('docs.json'));print('valid')"`
+Expected: `valid`
+
+- [ ] **Step 2: All internal coding-plan links point to existing files**
+
+Run:
+```bash
+grep -rhoE "/(en|id)/coding-plan/[a-z-]+" en/coding-plan id/coding-plan | sort -u | while read l; do f=".${l}.mdx"; test -f "$f" || echo "BROKEN: $l"; done
+```
+Expected: no "BROKEN" output.
+
+- [ ] **Step 3: Mintlify link check (if CLI available)**
+
+Run: `command -v mintlify >/dev/null && mintlify broken-links || echo "mintlify CLI not installed — skipped"`
+Expected: no broken links, or the skip message.
+
+- [ ] **Step 4: Confirm no forbidden model IDs introduced**
+
+Run: `grep -rnE "claude-opus-4-6|gemini-3-pro-preview|neosantara-gen" en/coding-plan/learning-path.mdx en/coding-plan/quota-and-limits.mdx id/coding-plan/learning-path.mdx id/coding-plan/quota-and-limits.mdx`
+Expected: no output.

--- a/docs/superpowers/plans/2026-07-03-coding-plan-learning-resources.md
+++ b/docs/superpowers/plans/2026-07-03-coding-plan-learning-resources.md
@@ -1,0 +1,609 @@
+# Coding Plan Learning Resources Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add a "Learning Resources" subgroup (Best Practice + Memory-mechanism) to the Coding Plan docs (EN + ID) and register it in `docs.json`.
+
+**Architecture:** Four vendor-neutral MDX pages using standard Mintlify components. New nav group after Guide/Panduan in both Coding Plan tabs.
+
+## Global Constraints
+
+- Vendor-neutral: NO Neosantara-specific tool references, NO model identifiers anywhere.
+- ID content uses "Kamu" (capital K); never "Anda".
+- Every MDX file has `title` + `description` frontmatter.
+- Every code fence declares a language.
+- Escape `<` / `<=` with backticks or unicode (`≤`).
+- Best Practice listed before Memory-mechanism in nav.
+- Git author: `ErRickow <er_rickow@neosantara.xyz>` (inline via `git -c`, no config change). Repo in detached HEAD.
+
+---
+
+### Task 1: Best Practice page (EN) — `en/coding-plan/best-practice.mdx`
+
+Create with the exact content below, then verify no model IDs (`grep -nE "claude-[0-9]|gemini-[0-9]|glm-[0-9]|deepseek-|qwen[0-9]|nsk_code" en/coding-plan/best-practice.mdx || echo clean` → `clean`), then commit `docs: add vendor-neutral Best Practice learning resource (EN)`.
+
+````mdx
+---
+title: "Best Practice"
+description: "A practical framework for working with coding agents — structuring tasks, planning, project rules, execution environment, skills, automation, and session management."
+---
+
+Modern coding agents do far more than autocomplete code: they read and navigate codebases, edit files, run commands, and complete multi-step tasks. Getting good results is less about clever prompts and more about how you structure the work around the agent. The practices below form a general framework that applies across tools.
+
+## 1. Treat Coding Agents as Collaborators, Not One-Off Assistants
+
+A common mistake is treating an agent like a question-and-answer box: ask, copy the answer, done. A coding agent is better understood as a configurable collaborator you refine over time — through project guidance, tool connections, and reusable workflows. Its value comes from the *combination* of model capability and the workflow you build around it, not the model alone.
+
+## 2. Structure Task Inputs: Context Beats Prompt Tricks
+
+In a real codebase, an effective task description usually has four parts:
+
+<CardGroup cols={2}>
+  <Card title="Goal">What to build or change — fix a bug, add an endpoint, refactor a module.</Card>
+  <Card title="Context">Relevant files, error messages, docs, or examples the agent should look at.</Card>
+  <Card title="Constraints">Engineering rules to follow — coding standards, architecture, security, dependency limits.</Card>
+  <Card title="Done when">How completion is judged — tests pass, behavior changes, the bug no longer reproduces.</Card>
+</CardGroup>
+
+Structured input reduces guesswork and makes changes easier to review.
+
+## 3. Plan Before Execution for Complex Tasks
+
+For anything non-trivial, asking the agent to write code immediately invites logic errors and rework. Have it **produce a plan first, then implement**: explore the codebase, identify the scope of changes, and confirm the approach before editing. Many agents offer a dedicated "plan" mode for exactly this.
+
+## 4. Capture Repeated Rules in Project-Level Configuration Files
+
+If you restate the same rules in every prompt, the workflow is inefficient and instructions drift. Move long-lived guidance into project-level configuration files the agent loads automatically:
+
+```text
+- Project directory structure
+- Build commands
+- Test workflow
+- Coding standards
+- PR submission process
+```
+
+The rule of thumb: **temporary instructions go in the prompt; long-lived rules go in project-level configuration files.**
+
+## 5. The Execution Environment Defines What the Agent Can Do
+
+Inconsistent results are often blamed on the model, but the cause is frequently an incomplete execution environment. Agents are expected to read/modify files, run build and test commands, call external tools, and use version control. When the environment is misconfigured, you see failures like:
+
+- can't locate the project directory
+- no permission to read or modify files
+- build or test commands fail
+- external tools or services are unreachable
+
+A coding agent depends on three kinds of context:
+
+| Context | What it covers |
+|---------|----------------|
+| Task Context | the prompt and input for the current task |
+| Project Context | repository structure and engineering rules |
+| Environment Context | tools, permissions, and execution environment |
+
+Environment Context determines **what the agent can do, and how far it can go**.
+
+## 6. Involve Coding Agents in the Full Development Loop
+
+A code change is rarely judged on generation alone — it must pass tests, meet standards, and survive review. Bring the agent into the whole loop:
+
+<Steps>
+  <Step title="Implement">Modify or add code per the task.</Step>
+  <Step title="Write/update tests">Add coverage for new behavior or the bug being fixed.</Step>
+  <Step title="Run the test suite">Verify the changes behave as expected.</Step>
+  <Step title="Run checks">Lint, format, and type-check to meet engineering standards.</Step>
+  <Step title="Review the diff">Inspect for regressions and unintended changes.</Step>
+</Steps>
+
+This shifts the agent from a code *generator* to an execution node in the development loop.
+
+## 7. Extend Agent Context with MCP
+
+Much of the context an agent needs lives outside the repo — issue trackers, CI status, database schemas, API docs. Copy-pasting it by hand doesn't scale. The **Model Context Protocol (MCP)** provides a standard way to connect external tools so the agent can retrieve real-time context directly. This expands the agent's context boundary from a repository-level executor to a collaborator that operates within your engineering environment.
+
+## 8. Capture Repeated Workflows as Skills
+
+Some tasks recur constantly — PR review, log analysis, release notes, standard debugging. Describing them from scratch each time is wasteful and inconsistent. Package them as **skills**: structured, reusable workflow templates the agent applies the same way every time.
+
+> If a prompt pattern or task flow is used repeatedly, it should probably be captured as a skill.
+
+## 9. Automate Stable Workflows
+
+Once a skill runs reliably, automate it. Many workflows are repetitive or time-based — commit summaries, investigating failed CI runs, scanning logs, weekly reports. A skill defines *how* a workflow runs; automation defines *when* it runs and how it continues over time. This turns the agent from an interactive tool into a continuous assistant.
+
+## 10. Manage Agent Sessions Deliberately
+
+A session is a working context that accumulates the task objective, relevant code, changes made, and intermediate reasoning. Left unmanaged, unrelated tasks pile up and degrade reasoning quality. Practical habits:
+
+- **One session per task** — keep the working context focused.
+- **Avoid overly long sessions** — summarize or compress when history grows.
+- **Branch explorations get their own session** — don't pile new investigations onto the original.
+- **Periodically compress history** — reduce pressure on the context window.
+
+Session management is a form of context management: a clear session keeps reasoning coherent across multi-step tasks.
+
+## Conclusion
+
+The effectiveness of a coding agent comes from the workflow you build around it: clear task context, planning, captured project rules, a solid execution environment, connected tools, reusable skills, automation, and deliberate session management. Together these turn a code-generation tool into a collaborator across the full development lifecycle.
+````
+
+---
+
+### Task 2: Best Practice page (ID) — `id/coding-plan/best-practice.mdx`
+
+Create with the exact content below, then verify (`grep -nw "Anda" ...` no output; model-ID grep → clean), then commit `docs: add vendor-neutral Best Practice learning resource (ID)`.
+
+````mdx
+---
+title: "Best Practice"
+description: "Kerangka praktis untuk bekerja dengan coding agent — menyusun tugas, perencanaan, aturan proyek, environment eksekusi, skill, otomatisasi, dan manajemen sesi."
+---
+
+Coding agent modern jauh lebih dari sekadar autocomplete: mereka membaca dan menavigasi codebase, mengedit file, menjalankan perintah, dan menyelesaikan tugas multi-langkah. Hasil yang bagus lebih ditentukan oleh cara Kamu menyusun pekerjaan di sekitar agent daripada trik prompt. Praktik di bawah ini adalah kerangka umum yang berlaku lintas tool.
+
+## 1. Perlakukan Coding Agent sebagai Kolaborator, Bukan Asisten Sekali Pakai
+
+Kesalahan umum adalah memperlakukan agent seperti kotak tanya-jawab: tanya, salin jawaban, selesai. Coding agent lebih tepat dipahami sebagai kolaborator yang bisa Kamu konfigurasi dan sempurnakan seiring waktu — lewat panduan proyek, koneksi tool, dan workflow yang bisa dipakai ulang. Nilainya datang dari *kombinasi* kapabilitas model dan workflow yang Kamu bangun di sekitarnya, bukan model saja.
+
+## 2. Susun Input Tugas: Konteks Mengalahkan Trik Prompt
+
+Di codebase nyata, deskripsi tugas yang efektif biasanya punya empat bagian:
+
+<CardGroup cols={2}>
+  <Card title="Goal">Apa yang dibuat atau diubah — perbaiki bug, tambah endpoint, refactor modul.</Card>
+  <Card title="Konteks">File terkait, pesan error, dokumentasi, atau contoh yang perlu dilihat agent.</Card>
+  <Card title="Constraint">Aturan engineering yang harus diikuti — standar kode, arsitektur, keamanan, batasan dependensi.</Card>
+  <Card title="Done when">Cara menilai selesai — test lulus, perilaku berubah, bug tidak muncul lagi.</Card>
+</CardGroup>
+
+Input terstruktur mengurangi tebak-tebakan dan membuat perubahan lebih mudah di-review.
+
+## 3. Rencanakan Sebelum Eksekusi untuk Tugas Kompleks
+
+Untuk tugas non-trivial, meminta agent langsung menulis kode mengundang error logika dan pekerjaan ulang. Minta agent **membuat rencana dulu, baru implementasi**: jelajahi codebase, identifikasi cakupan perubahan, dan konfirmasi pendekatannya sebelum mengedit. Banyak agent menyediakan mode "plan" khusus untuk ini.
+
+## 4. Simpan Aturan Berulang di File Konfigurasi Tingkat Proyek
+
+Kalau Kamu mengulang aturan yang sama di tiap prompt, workflow jadi tidak efisien dan instruksi mudah melenceng. Pindahkan panduan jangka panjang ke file konfigurasi tingkat proyek yang dimuat agent otomatis:
+
+```text
+- Struktur direktori proyek
+- Perintah build
+- Alur test
+- Standar kode
+- Proses submit PR
+```
+
+Patokannya: **instruksi sementara di prompt; aturan jangka panjang di file konfigurasi proyek.**
+
+## 5. Environment Eksekusi Menentukan Apa yang Bisa Dilakukan Agent
+
+Hasil yang tidak konsisten sering disalahkan ke model, padahal penyebabnya kerap environment eksekusi yang tidak lengkap. Agent diharapkan membaca/mengubah file, menjalankan perintah build dan test, memanggil tool eksternal, dan memakai version control. Saat environment salah konfigurasi, muncul kegagalan seperti:
+
+- tidak menemukan direktori proyek
+- tidak punya izin membaca atau mengubah file
+- perintah build atau test gagal
+- tool atau layanan eksternal tidak terjangkau
+
+Coding agent bergantung pada tiga jenis konteks:
+
+| Konteks | Cakupan |
+|---------|---------|
+| Task Context | prompt dan input untuk tugas saat ini |
+| Project Context | struktur repositori dan aturan engineering |
+| Environment Context | tool, izin, dan environment eksekusi |
+
+Environment Context menentukan **apa yang bisa dilakukan agent, dan seberapa jauh**.
+
+## 6. Libatkan Coding Agent di Seluruh Development Loop
+
+Sebuah perubahan kode jarang dinilai dari hasil generasi saja — ia harus lulus test, memenuhi standar, dan melewati review. Libatkan agent di seluruh loop:
+
+<Steps>
+  <Step title="Implementasi">Ubah atau tambah kode sesuai tugas.</Step>
+  <Step title="Tulis/update test">Tambah cakupan untuk perilaku baru atau bug yang diperbaiki.</Step>
+  <Step title="Jalankan test suite">Verifikasi perubahan berperilaku sesuai harapan.</Step>
+  <Step title="Jalankan pemeriksaan">Lint, format, dan type-check agar memenuhi standar engineering.</Step>
+  <Step title="Review diff">Periksa regresi dan perubahan tak disengaja.</Step>
+</Steps>
+
+Ini menggeser agent dari *generator* kode menjadi simpul eksekusi dalam development loop.
+
+## 7. Perluas Konteks Agent dengan MCP
+
+Banyak konteks yang dibutuhkan agent ada di luar repo — issue tracker, status CI, skema database, dokumentasi API. Menyalin-tempel manual tidak scalable. **Model Context Protocol (MCP)** menyediakan cara standar untuk menghubungkan tool eksternal sehingga agent bisa mengambil konteks real-time langsung. Ini memperluas batas konteks agent dari eksekutor tingkat repositori menjadi kolaborator yang beroperasi di dalam environment engineering-mu.
+
+## 8. Tangkap Workflow Berulang sebagai Skill
+
+Beberapa tugas muncul terus-menerus — review PR, analisis log, catatan rilis, debugging standar. Menjelaskannya dari nol tiap kali itu boros dan tidak konsisten. Kemas jadi **skill**: template workflow terstruktur yang bisa dipakai ulang dan diterapkan agent dengan cara yang sama setiap kali.
+
+> Kalau sebuah pola prompt atau alur tugas dipakai berulang, sebaiknya jadikan skill.
+
+## 9. Otomatiskan Workflow yang Stabil
+
+Setelah sebuah skill berjalan andal, otomatiskan. Banyak workflow bersifat repetitif atau berbasis waktu — ringkasan commit, investigasi CI yang gagal, memindai log, laporan mingguan. Skill mendefinisikan *bagaimana* workflow berjalan; otomatisasi mendefinisikan *kapan* ia berjalan dan bagaimana berlanjut seiring waktu. Ini mengubah agent dari tool interaktif menjadi asisten berkelanjutan.
+
+## 10. Kelola Sesi Agent secara Sengaja
+
+Sebuah sesi adalah working context yang mengumpulkan tujuan tugas, kode terkait, perubahan yang dibuat, dan reasoning perantara. Tanpa pengelolaan, tugas tak terkait menumpuk dan menurunkan kualitas reasoning. Kebiasaan praktis:
+
+- **Satu sesi per tugas** — jaga working context tetap fokus.
+- **Hindari sesi terlalu panjang** — ringkas atau kompres saat riwayat membengkak.
+- **Eksplorasi cabang pakai sesi sendiri** — jangan menumpuk investigasi baru ke sesi asli.
+- **Kompres riwayat berkala** — kurangi tekanan pada context window.
+
+Manajemen sesi adalah bentuk manajemen konteks: sesi yang jelas menjaga reasoning tetap koheren di tugas multi-langkah.
+
+## Kesimpulan
+
+Efektivitas coding agent datang dari workflow yang Kamu bangun di sekitarnya: konteks tugas yang jelas, perencanaan, aturan proyek yang tersimpan, environment eksekusi yang solid, tool yang terhubung, skill yang bisa dipakai ulang, otomatisasi, dan manajemen sesi yang sengaja. Bersama-sama, semua ini mengubah tool generasi kode menjadi kolaborator di seluruh siklus pengembangan.
+````
+
+---
+
+### Task 3: Memory-mechanism page (EN) — `en/coding-plan/memory-mechanism.mdx`
+
+Create with the exact content below, verify no model IDs → clean, commit `docs: add vendor-neutral Memory Mechanism learning resource (EN)`.
+
+````mdx
+---
+title: "Memory Mechanism"
+description: "How coding agents retain context across tasks and sessions — memory types, the retrieve-assemble-update pattern, layered memory, and troubleshooting."
+---
+
+Memory lets a coding agent retain context across tasks and sessions, reducing repeated input and improving efficiency. With a good memory design, an agent keeps understanding the project structure, engineering conventions, and your preferences, and reuses that information in later work. Memory is usually organized into layers such as session, project, and long-term memory.
+
+## Why Coding Agents Need Memory
+
+Language models do not preserve state between calls on their own. They can't remember project context across sessions, accumulate experience, or consistently adapt to your preferences. Agent systems solve this with **external memory**. A typical loop looks like this:
+
+```text
+User input
+   ↓
+Memory retrieval
+   ↓
+Context assembly
+   ↓
+Model reasoning
+   ↓
+Action / tool call
+   ↓
+Memory update
+```
+
+The agent retrieves relevant memory before a task and updates memory after it — a common pattern in modern agent systems.
+
+## Memory Architecture
+
+At a high level:
+
+```text
+Short-term memory
+    └ session context
+
+Long-term memory
+    ├ semantic memory
+    ├ episodic memory
+    └ procedural memory
+```
+
+## Core Memory Types
+
+<AccordionGroup>
+  <Accordion title="Session memory">
+    Context tied to the current task — conversation history, recent tool outputs, the current plan, and files in scope. Usually lives in the model's context window.
+  </Accordion>
+  <Accordion title="Project memory">
+    Long-lived information about the whole codebase — architecture, coding standards, build workflows, common commands. Typically written into `.md` files and loaded at the start of a session.
+  </Accordion>
+  <Accordion title="Semantic memory">
+    Factual knowledge and reference material — API docs, language rules, knowledge bases. Often implemented with retrieval-augmented generation (RAG): embed the query, search a vector store, retrieve documents, then reason.
+  </Accordion>
+  <Accordion title="Episodic memory">
+    Records of past experiences — how a previous bug was fixed, the root cause of a build failure, a debugging strategy that worked. Helps the agent learn from prior work.
+  </Accordion>
+  <Accordion title="Procedural memory">
+    Step-by-step workflows for completing tasks — e.g. a debugging routine: read the error log, locate the file, write the patch, run tests. Used in prompt engineering, workflow templates, and policies.
+  </Accordion>
+</AccordionGroup>
+
+## The Standard Memory Pattern
+
+<Steps>
+  <Step title="Memory retrieval">
+    Before a task, the agent retrieves relevant project memory, knowledge-base entries, and prior experience, then injects them into the working context.
+  </Step>
+  <Step title="Context construction">
+    Retrieved memories are assembled into a complete context and passed to the model.
+  </Step>
+  <Step title="Memory update">
+    After the task, the agent decides whether to write new memories — newly discovered rules, debugging experience, or preferences.
+  </Step>
+</Steps>
+
+## Using Memory Correctly
+
+Effective memory is **layered, controllable, retrievable, and updatable**. Rather than expecting the model to "remember everything," establish a clear pattern for what goes where.
+
+### Separate instruction memory from learning memory
+
+- **Instruction memory** is written by humans to tell the agent how to work — coding standards, directory conventions, build/test commands, naming, commit rules, safety rules.
+- **Learning memory** is accumulated over time from your corrections, preferences, failed attempts, and habits.
+
+Mixing them causes behavior to drift. Write **rules and constraints** into instruction memory (stable, predictable), and **experience and preferences** into learning memory (improves over time). Keeping them separate stops experience notes from polluting core rules.
+
+### Layered memory management
+
+| Layer | Scope | Examples |
+|-------|-------|----------|
+| Organization | all developers/projects | security & compliance, review standards, restricted directories, dependency/license constraints |
+| Project | team-shared, version-controlled | architecture, directory conventions, build/test commands, naming, workflows |
+| User | personal, across projects | preferred style, debugging sequence, output format, shortcuts |
+| Local | this machine, not committed | test accounts, local ports, mock endpoints, machine-specific notes |
+| Role / agent | one specialized agent | test commands for a testing agent, module boundaries for a refactoring agent |
+
+Organization memory is the highest-priority governance layer and should not be casually bypassed. Project memory is the most important shared layer.
+
+### Load `.md` files by path
+
+For large repositories, split instructions into multiple topic-focused Markdown files (e.g. `testing.md`, `api-design.md`, `security.md`) and load them by path only when relevant. Three principles:
+
+- Keep the main memory file limited to global shared context.
+- Keep specialized rules modular — one topic per file.
+- If a rule can be loaded by path, don't load it globally; bring it in only when needed.
+
+A memory structure might look like this:
+
+```text
+agent-memory/
+├── project.md            # Project overview
+├── rules/
+│   ├── code-style.md     # Code style
+│   ├── testing.md        # Testing conventions
+│   ├── api-design.md     # API design guidelines
+│   ├── security.md       # Security requirements
+│   └── frontend/
+│       └── react.md      # Frontend-specific rules
+└── local/
+    └── developer.local.md
+```
+
+### Write memory rules as concrete instructions
+
+Use specific, verifiable rules rather than vague principles. Prefer:
+
+- Use 2-space indentation in all new TypeScript files.
+- Run `pnpm test` after modifying business logic.
+- Place all API handlers under `src/api/handlers/`.
+- Keep page components under 300 lines; split larger ones into hooks or child components.
+
+Over vague statements like "keep the code clean" or "write good tests." Keep the main memory file concise (ideally under ~200 lines) and use Markdown headings and lists.
+
+### Separate shared rules from personal preferences
+
+Define each rule's scope and owner: project (team, version-controlled), organization (central IT/DevOps), user (individual), local (single machine), role (a specialized agent). The guiding question is: **who owns it, who shares it, and who it applies to.** Clear boundaries prevent rule sprawl and duplicate definitions.
+
+### Reuse memory through imports and rule packages
+
+Many rules are shared conventions across repositories. Rewriting them everywhere invites inconsistency. Where the tooling supports it, import shared rule files or link a shared rules directory, and build reusable rule packages (e.g. security rules, frontend rules, testing rules). Each project references only the modules it needs, so rules are maintained centrally and applied consistently.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="The agent isn't following my .md memory files">
+    `.md` files are contextual instructions, not enforced configuration. The agent tries to follow them but can't guarantee compliance when rules are vague or conflicting. Confirm the files loaded, that they're in an allowed path/scope, and that no two files give conflicting instructions for the same behavior.
+  </Accordion>
+  <Accordion title="I don't know what auto-memory has saved">
+    Many agents keep background auto-memory as Markdown files. Use the tool's memory command to view the memory directory, then read, edit, or delete those files directly.
+  </Accordion>
+  <Accordion title="My memory files are too large">
+    Oversized files consume context window, reduce adherence, and increase conflicts. Split detailed content into multiple Markdown files and reference or import them, or move rules into a dedicated `rules/` directory.
+  </Accordion>
+  <Accordion title="Instructions disappear after context compression">
+    Long conversations get compressed. Memory files are typically reloaded from disk afterward, so only content written into files persists. If a rule disappears after compression, it lived only in the conversation. Write long-term instructions into `.md` files instead of relying on the conversation.
+  </Accordion>
+</AccordionGroup>
+````
+
+---
+
+### Task 4: Memory-mechanism page (ID) — `id/coding-plan/memory-mechanism.mdx`
+
+Create with the exact content below, verify (no "Anda"; no model IDs → clean), commit `docs: add vendor-neutral Memory Mechanism learning resource (ID)`.
+
+````mdx
+---
+title: "Mekanisme Memori"
+description: "Cara coding agent menyimpan konteks lintas tugas dan sesi — jenis memori, pola retrieve-assemble-update, memori berlapis, dan troubleshooting."
+---
+
+Memori memungkinkan coding agent menyimpan konteks lintas tugas dan sesi, mengurangi input berulang dan meningkatkan efisiensi. Dengan desain memori yang baik, agent terus memahami struktur proyek, konvensi engineering, dan preferensi Kamu, lalu memakainya ulang di pekerjaan berikutnya. Memori biasanya diatur berlapis seperti sesi, proyek, dan memori jangka panjang.
+
+## Kenapa Coding Agent Butuh Memori
+
+Model bahasa tidak menyimpan state antar panggilan dengan sendirinya. Mereka tidak bisa mengingat konteks proyek lintas sesi, mengakumulasi pengalaman, atau konsisten menyesuaikan preferensimu. Sistem agent mengatasinya dengan **memori eksternal**. Loop tipikalnya:
+
+```text
+Input user
+   ↓
+Pengambilan memori
+   ↓
+Perakitan konteks
+   ↓
+Reasoning model
+   ↓
+Aksi / tool call
+   ↓
+Pembaruan memori
+```
+
+Agent mengambil memori relevan sebelum tugas dan memperbaruinya setelah selesai — pola umum di sistem agent modern.
+
+## Arsitektur Memori
+
+Secara garis besar:
+
+```text
+Memori jangka pendek
+    └ konteks sesi
+
+Memori jangka panjang
+    ├ memori semantik
+    ├ memori episodik
+    └ memori prosedural
+```
+
+## Jenis Memori Inti
+
+<AccordionGroup>
+  <Accordion title="Memori sesi">
+    Konteks yang terikat tugas saat ini — riwayat percakapan, output tool terbaru, rencana saat ini, dan file dalam cakupan. Biasanya ada di context window model.
+  </Accordion>
+  <Accordion title="Memori proyek">
+    Informasi jangka panjang tentang seluruh codebase — arsitektur, standar kode, alur build, perintah umum. Biasanya ditulis ke file `.md` dan dimuat di awal sesi.
+  </Accordion>
+  <Accordion title="Memori semantik">
+    Pengetahuan faktual dan materi referensi — dokumentasi API, aturan bahasa, basis pengetahuan. Sering diimplementasikan dengan retrieval-augmented generation (RAG): embed query, cari di vector store, ambil dokumen, lalu reasoning.
+  </Accordion>
+  <Accordion title="Memori episodik">
+    Catatan pengalaman masa lalu — cara bug sebelumnya diperbaiki, akar penyebab kegagalan build, strategi debugging yang berhasil. Membantu agent belajar dari pekerjaan sebelumnya.
+  </Accordion>
+  <Accordion title="Memori prosedural">
+    Alur langkah demi langkah untuk menyelesaikan tugas — mis. rutinitas debugging: baca error log, cari file, tulis patch, jalankan test. Dipakai di prompt engineering, template workflow, dan policy.
+  </Accordion>
+</AccordionGroup>
+
+## Pola Memori Standar
+
+<Steps>
+  <Step title="Pengambilan memori">
+    Sebelum tugas, agent mengambil memori proyek, entri basis pengetahuan, dan pengalaman relevan, lalu menyuntikkannya ke working context.
+  </Step>
+  <Step title="Perakitan konteks">
+    Memori yang diambil dirakit jadi konteks lengkap dan diteruskan ke model.
+  </Step>
+  <Step title="Pembaruan memori">
+    Setelah tugas, agent memutuskan apakah menulis memori baru — aturan yang baru ditemukan, pengalaman debugging, atau preferensi.
+  </Step>
+</Steps>
+
+## Memakai Memori dengan Benar
+
+Memori yang efektif itu **berlapis, terkontrol, bisa diambil, dan bisa diperbarui**. Alih-alih berharap model "mengingat semuanya", buat pola jelas tentang apa yang disimpan di mana.
+
+### Pisahkan memori instruksi dari memori pembelajaran
+
+- **Memori instruksi** ditulis manusia untuk memberi tahu agent cara bekerja — standar kode, konvensi direktori, perintah build/test, penamaan, aturan commit, aturan keamanan.
+- **Memori pembelajaran** terakumulasi seiring waktu dari koreksi, preferensi, percobaan yang gagal, dan kebiasaanmu.
+
+Mencampurnya membuat perilaku melenceng. Tulis **aturan dan batasan** ke memori instruksi (stabil, dapat diprediksi), dan **pengalaman serta preferensi** ke memori pembelajaran (membaik seiring waktu). Memisahkannya mencegah catatan pengalaman mencemari aturan inti.
+
+### Manajemen memori berlapis
+
+| Lapisan | Cakupan | Contoh |
+|---------|---------|--------|
+| Organisasi | semua developer/proyek | keamanan & kepatuhan, standar review, direktori terbatas, batasan dependensi/lisensi |
+| Proyek | dibagi tim, version-controlled | arsitektur, konvensi direktori, perintah build/test, penamaan, workflow |
+| User | personal, lintas proyek | gaya favorit, urutan debugging, format output, shortcut |
+| Lokal | mesin ini, tidak di-commit | akun test, port lokal, endpoint mock, catatan spesifik mesin |
+| Role / agent | satu agent khusus | perintah test untuk testing agent, batas modul untuk refactoring agent |
+
+Memori organisasi adalah lapisan tata kelola prioritas tertinggi dan tidak boleh dilewati sembarangan. Memori proyek adalah lapisan bersama yang paling penting.
+
+### Muat file `.md` berdasarkan path
+
+Untuk repositori besar, pecah instruksi ke beberapa file Markdown fokus per topik (mis. `testing.md`, `api-design.md`, `security.md`) dan muat berdasarkan path hanya saat relevan. Tiga prinsip:
+
+- Batasi file memori utama untuk konteks bersama global.
+- Buat aturan khusus modular — satu topik per file.
+- Kalau aturan bisa dimuat lewat path, jangan muat global; bawa hanya saat dibutuhkan.
+
+Struktur memori bisa terlihat seperti ini:
+
+```text
+agent-memory/
+├── project.md            # Ringkasan proyek
+├── rules/
+│   ├── code-style.md     # Gaya kode
+│   ├── testing.md        # Konvensi testing
+│   ├── api-design.md     # Panduan desain API
+│   ├── security.md       # Persyaratan keamanan
+│   └── frontend/
+│       └── react.md      # Aturan khusus frontend
+└── local/
+    └── developer.local.md
+```
+
+### Tulis aturan memori sebagai instruksi konkret
+
+Pakai aturan spesifik dan bisa diverifikasi, bukan prinsip abstrak. Lebih baik:
+
+- Pakai indentasi 2 spasi di semua file TypeScript baru.
+- Jalankan `pnpm test` setelah mengubah logika bisnis.
+- Letakkan semua API handler di `src/api/handlers/`.
+- Jaga komponen halaman di bawah 300 baris; pecah yang lebih besar jadi hook atau komponen anak.
+
+Ketimbang pernyataan kabur seperti "jaga kode tetap bersih" atau "tulis test yang baik". Jaga file memori utama ringkas (idealnya di bawah ~200 baris) dan pakai heading serta list Markdown.
+
+### Pisahkan aturan bersama dari preferensi pribadi
+
+Definisikan cakupan dan pemilik tiap aturan: proyek (tim, version-controlled), organisasi (IT/DevOps pusat), user (individu), lokal (satu mesin), role (agent khusus). Pertanyaan pemandunya: **siapa yang memiliki, siapa yang berbagi, dan berlaku untuk siapa.** Batasan yang jelas mencegah aturan membengkak dan duplikasi.
+
+### Pakai ulang memori lewat import dan paket aturan
+
+Banyak aturan adalah konvensi bersama lintas repositori. Menulis ulang di tiap repo mengundang inkonsistensi. Bila tooling mendukung, import file aturan bersama atau tautkan direktori aturan bersama, dan bangun paket aturan yang bisa dipakai ulang (mis. aturan keamanan, aturan frontend, aturan testing). Tiap proyek mereferensikan hanya modul yang dibutuhkan, sehingga aturan dikelola terpusat dan diterapkan konsisten.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Agent tidak mengikuti file memori .md saya">
+    File `.md` adalah instruksi kontekstual, bukan konfigurasi yang dipaksakan. Agent berusaha mengikutinya tapi tidak bisa menjamin kepatuhan saat aturan kabur atau bertabrakan. Pastikan file termuat, berada di path/scope yang diizinkan, dan tidak ada dua file yang memberi instruksi bertentangan untuk perilaku yang sama.
+  </Accordion>
+  <Accordion title="Saya tidak tahu apa yang disimpan auto-memory">
+    Banyak agent menyimpan auto-memory latar sebagai file Markdown. Pakai perintah memori tool untuk melihat direktori memori, lalu baca, edit, atau hapus file itu langsung.
+  </Accordion>
+  <Accordion title="File memori saya terlalu besar">
+    File berukuran besar memakan context window, menurunkan kepatuhan, dan menambah konflik. Pecah konten detail ke beberapa file Markdown dan referensikan atau import, atau pindahkan aturan ke direktori `rules/` khusus.
+  </Accordion>
+  <Accordion title="Instruksi hilang setelah kompresi konteks">
+    Percakapan panjang dikompres. File memori biasanya dimuat ulang dari disk setelahnya, jadi hanya konten yang tertulis di file yang bertahan. Kalau aturan hilang setelah kompresi, aturan itu hanya ada di percakapan. Tulis instruksi jangka panjang ke file `.md`, jangan mengandalkan percakapan.
+  </Accordion>
+</AccordionGroup>
+````
+
+---
+
+### Task 5: Register the Learning Resources subgroup in docs.json
+
+Add, after the EN "Guide" group (inside the `"tab": "Coding Plan"` EN tab), a new group:
+```json
+              {
+                "group": "Learning Resources",
+                "pages": [
+                  "en/coding-plan/best-practice",
+                  "en/coding-plan/memory-mechanism"
+                ]
+              }
+```
+And after the ID "Panduan" group (inside the ID Coding Plan tab):
+```json
+              {
+                "group": "Sumber Belajar",
+                "pages": [
+                  "id/coding-plan/best-practice",
+                  "id/coding-plan/memory-mechanism"
+                ]
+              }
+```
+Add a comma after the preceding group's closing brace. Match surrounding indentation. Verify `python3 -c "import json;json.load(open('docs.json'));print('valid')"` → `valid`. Commit `docs: register Learning Resources subgroup in Coding Plan nav`.
+
+---
+
+### Task 6: Final verification (no files)
+
+- `python3 -c "import json;json.load(open('docs.json'));print('valid')"` → `valid`
+- `grep -nE "Learning Resources|Sumber Belajar" docs.json` → two lines
+- All four new files exist
+- `grep -rnE "claude-[0-9]|gemini-[0-9]|glm-[0-9]|deepseek-|qwen[0-9]|nsk_code" en/coding-plan/best-practice.mdx en/coding-plan/memory-mechanism.mdx id/coding-plan/best-practice.mdx id/coding-plan/memory-mechanism.mdx || echo clean` → `clean`
+- `grep -rnw "Anda" id/coding-plan/best-practice.mdx id/coding-plan/memory-mechanism.mdx || echo clean` → `clean`

--- a/docs/superpowers/specs/2026-07-03-coding-plan-learning-path-and-quota-design.md
+++ b/docs/superpowers/specs/2026-07-03-coding-plan-learning-path-and-quota-design.md
@@ -1,0 +1,105 @@
+# Coding Plan — Learning Path & Quota & Limits Pages
+
+Date: 2026-07-03
+Status: Approved for implementation
+
+## Goal
+
+Add two new pages to the Coding Plan docs (EN + ID) and register them in
+`docs.json`, then trim duplicated quota content from existing pages so the new
+Quota & Limits page is the single source of truth.
+
+1. **Learning Path** — a hybrid start-here navigation hub.
+2. **Quota & Limits** — the canonical reference for prompt-based quota, windows,
+   tiers, and load multipliers.
+
+## Scope decisions (from brainstorming)
+
+- **Consolidation: Option B** — add the new pages AND trim duplicated
+  quota/multiplier blocks in existing pages, replacing them with pointers to the
+  canonical Quota & Limits page.
+- **Learning Path: Option C (hybrid)** — a sequential start-here spine plus
+  profile-based shortcut cards.
+
+## New files
+
+- `en/coding-plan/learning-path.mdx`
+- `id/coding-plan/learning-path.mdx`
+- `en/coding-plan/quota-and-limits.mdx`
+- `id/coding-plan/quota-and-limits.mdx`
+
+## Navigation (docs.json)
+
+In both the EN "Coding Plan" tab and the ID "Coding Plan" tab, update the first
+group's pages ordering:
+
+```
+Group "Coding Plan":
+  - <lang>/coding-plan/learning-path      (NEW, first — start-here on-ramp)
+  - <lang>/coding-plan/overview
+  - <lang>/coding-plan/quota-and-limits   (NEW, after overview — reference)
+  - <lang>/coding-plan/usage-policy
+  - <lang>/coding-plan/faq
+Group "Guide" / "Panduan": unchanged
+  - quick-start, jelma, tool-integration, switching-models
+```
+
+## Learning Path page (hybrid)
+
+Mirrored EN/ID; ID uses "Kamu". Pure navigation hub — no config snippets, no
+quota numbers (nothing to keep in sync).
+
+1. Intro — one line: what the Coding Plan is, "start here".
+2. Start-here spine — `<Steps>` linking existing pages in order:
+   Subscribe & get key → Connect a tool (Tool Integration) or Jelma →
+   First prompt (Quick Start) → Understand quota (Quota & Limits) →
+   Optimize (Switching Models).
+3. Shortcut `<CardGroup>`:
+   - Zero setup → Jelma
+   - I use Claude Code / Cline / Cursor → Tool Integration
+   - Minimize quota burn → Quota & Limits + Switching Models
+   - Rules & fair use → Usage Policy
+
+## Quota & Limits page (canonical)
+
+1. What counts as a prompt — 1 user turn = 1 prompt (~15–20 model calls under
+   the hood), with a short worked example.
+2. Quota windows — 5-hour rolling + weekly, auto-reset, no overage / hard-stop.
+3. Plan tiers table — Hemat / Reguler / Eksklusif limits + price (single
+   canonical copy).
+4. Load-based multipliers — 2×/3× flagship table + the dynamic "under load"
+   `<Note>` (the one true source, moved from switching-models).
+5. Tips to conserve quota — lightweight vs premium model guidance.
+6. Cross-links — Switching Models, Usage Policy.
+
+## Trimming existing pages (Option B)
+
+- `overview.mdx` (EN+ID): keep a 2–3 line quota summary; replace the "Plans"
+  table + detailed quota bullets with a link to the canonical page.
+- `switching-models.mdx` (EN+ID): remove the full "Load-Based Quota Multipliers"
+  table + Note; replace with a one-line pointer. Keep the per-task model
+  recommendation table (switching-specific, not quota).
+- `quick-start.mdx` (EN+ID): keep the onboarding "Tips for Efficient Quota
+  Usage" section but trim the multiplier restatement to a pointer.
+- `faq.mdx` (EN+ID): keep FAQ accordions (Q&A serves search) but link quota
+  answers to the canonical page instead of restating numbers.
+
+The tier/pricing table lives canonically in Quota & Limits; other pages link to it.
+
+## Constraints & conventions (AGENTS.md)
+
+- ID content uses "Kamu" (capital K).
+- Internal links are root-relative (e.g. `/en/coding-plan/quota-and-limits`).
+- Every MDX file has `title` + `description` frontmatter.
+- Escape `<` / `<=` in tables/text with backticks or unicode.
+- No new model identifiers — reuse only IDs already present in existing
+  coding-plan pages (`claude-4.5-sonnet`, `claude-4.5-opus`, `gemini-3-flash`,
+  `glm-4.7-flash`, `deepseek-r1`, `qwen3-32b`).
+
+## Verification
+
+- Keep `docs.json` valid JSON.
+- Verify every internal link resolves to a real page path.
+- Run Mintlify broken-links check if the CLI is available; otherwise verify
+  links manually.
+- No new model names introduced.

--- a/docs/superpowers/specs/2026-07-03-coding-plan-learning-resources-design.md
+++ b/docs/superpowers/specs/2026-07-03-coding-plan-learning-resources-design.md
@@ -1,0 +1,95 @@
+# Coding Plan — Learning Resources Subgroup (Best Practice + Memory Mechanism)
+
+Date: 2026-07-03
+Status: Approved for implementation
+
+## Goal
+
+Add a "Learning Resources" subgroup to the Coding Plan docs (EN + ID) with two
+vendor-neutral educational pages — Best Practice and Memory-mechanism — modeled
+on z.ai's devpack resources, and register them in `docs.json`.
+
+## Scope decisions (from brainstorming)
+
+- **Content style: Option C — vendor-neutral.** Original prose covering the same
+  concepts as the reference pages, with NO Neosantara-specific tool or model
+  references and NO model identifiers. Generic "coding agent" terminology.
+- Not a verbatim copy of z.ai; original writing of the shared concepts.
+
+## New files
+
+- `en/coding-plan/best-practice.mdx`
+- `id/coding-plan/best-practice.mdx`
+- `en/coding-plan/memory-mechanism.mdx`
+- `id/coding-plan/memory-mechanism.mdx`
+
+## Navigation (docs.json)
+
+Add a new group after "Guide" (EN) / "Panduan" (ID) in both Coding Plan tabs:
+
+```
+Group "Learning Resources" (EN) / "Sumber Belajar" (ID):
+  - <lang>/coding-plan/best-practice
+  - <lang>/coding-plan/memory-mechanism
+```
+
+Best Practice listed first (matches the reference).
+
+## Best Practice page
+
+Vendor-neutral original prose. Ten `##` sections:
+
+1. Treat coding agents as collaborators, not one-off assistants
+2. Structure task inputs — Goal / Context / Constraints / Done-when
+3. Plan before execution for complex tasks
+4. Capture repeated rules in project-level configuration files
+5. The execution environment defines what the agent can do
+   (Task Context / Project Context / Environment Context)
+6. Involve coding agents in the full development loop
+   (implement -> write/update tests -> run suite -> run checks -> review)
+7. Extend agent context with MCP
+8. Capture repeated workflows as skills
+9. Automate stable workflows
+10. Manage agent sessions deliberately
+
+No vendor names, no model IDs. Use generic "coding agent" throughout.
+
+## Memory-mechanism page
+
+Vendor-neutral original prose:
+
+- Why coding agents need memory (+ retrieve -> assemble -> reason -> act ->
+  update loop as a fenced code diagram)
+- Memory architecture: short-term (session) vs long-term (semantic / episodic /
+  procedural)
+- Core memory types (session, project, semantic, episodic, procedural)
+- The standard memory pattern (retrieve -> assemble context -> update)
+- Using memory correctly:
+  - separate instruction memory from learning memory
+  - layered memory management (organization / project / user / local / role)
+  - load `.md` files by path
+  - write memory rules as concrete instructions
+  - separate shared rules from personal preferences
+  - reuse memory through imports and rule packages
+- Troubleshooting (accordions)
+
+Generic `.md` / rules directory examples presented as common conventions, not
+as any specific product's proprietary feature.
+
+## Conventions & constraints (AGENTS.md)
+
+- ID content uses "Kamu" (capital K); never "Anda".
+- Every MDX file has `title` + `description` frontmatter.
+- Internal links (if any) are root-relative.
+- Escape `<` / `<=` with backticks or unicode (`≤`); MDX-safe.
+- Every code fence declares a language.
+- No model identifiers anywhere (vendor-neutral).
+- Git author identity for commits: `ErRickow <er_rickow@neosantara.xyz>` (inline
+  via `git -c`, no config change). Repo is in detached HEAD.
+
+## Verification
+
+- `docs.json` stays valid JSON.
+- Both Coding Plan tabs contain the new subgroup with both pages.
+- All four new files exist and have frontmatter.
+- No model identifiers present in the new pages.

--- a/en/about/rate-limits.mdx
+++ b/en/about/rate-limits.mdx
@@ -23,11 +23,11 @@ The system enforces three types of throughput limits:
 
 | Tier | RPM | ITPM | OTPM |
 | :--- | :--- | :--- | :--- |
-| Free | 3 | 15,000 | 2,000 |
-| Basic | 50 | 50,000 | 10,000 |
-| Standard | 1,000 | 450,000 | 90,000 |
-| Pro | 2,000 | 1,000,000 | 200,000 |
-| Enterprise | 4,000 | 4,000,000 | 800,000 |
+| Free | 15 | 30,000 | 8,000 |
+| Basic | 50 | 500,000 | 80,000 |
+| Standard | 1,000 | 2,000,000 | 320,000 |
+| Pro | 2,000 | 5,000,000 | 800,000 |
+| Enterprise | 4,000 | 10,000,000 | 1,600,000 |
 
 <Note>
 **Tier Upgrades:** Throughput tiers are automatically adjusted based on your total deposit history. See [Token Credits & Pricing](/en/about/billing-pricing#throughput-tiers-speed-limits) for details.

--- a/en/coding-plan/best-practice.mdx
+++ b/en/coding-plan/best-practice.mdx
@@ -1,0 +1,103 @@
+---
+title: "Best Practice"
+description: "A practical framework for working with coding agents — structuring tasks, planning, project rules, execution environment, skills, automation, and session management."
+---
+
+Modern coding agents do far more than autocomplete code: they read and navigate codebases, edit files, run commands, and complete multi-step tasks. Getting good results is less about clever prompts and more about how you structure the work around the agent. The practices below form a general framework that applies across tools.
+
+## 1. Treat Coding Agents as Collaborators, Not One-Off Assistants
+
+A common mistake is treating an agent like a question-and-answer box: ask, copy the answer, done. A coding agent is better understood as a configurable collaborator you refine over time — through project guidance, tool connections, and reusable workflows. Its value comes from the *combination* of model capability and the workflow you build around it, not the model alone.
+
+## 2. Structure Task Inputs: Context Beats Prompt Tricks
+
+In a real codebase, an effective task description usually has four parts:
+
+<CardGroup cols={2}>
+  <Card title="Goal">What to build or change — fix a bug, add an endpoint, refactor a module.</Card>
+  <Card title="Context">Relevant files, error messages, docs, or examples the agent should look at.</Card>
+  <Card title="Constraints">Engineering rules to follow — coding standards, architecture, security, dependency limits.</Card>
+  <Card title="Done when">How completion is judged — tests pass, behavior changes, the bug no longer reproduces.</Card>
+</CardGroup>
+
+Structured input reduces guesswork and makes changes easier to review.
+
+## 3. Plan Before Execution for Complex Tasks
+
+For anything non-trivial, asking the agent to write code immediately invites logic errors and rework. Have it **produce a plan first, then implement**: explore the codebase, identify the scope of changes, and confirm the approach before editing. Many agents offer a dedicated "plan" mode for exactly this.
+
+## 4. Capture Repeated Rules in Project-Level Configuration Files
+
+If you restate the same rules in every prompt, the workflow is inefficient and instructions drift. Move long-lived guidance into project-level configuration files the agent loads automatically:
+
+```text
+- Project directory structure
+- Build commands
+- Test workflow
+- Coding standards
+- PR submission process
+```
+
+The rule of thumb: **temporary instructions go in the prompt; long-lived rules go in project-level configuration files.**
+
+## 5. The Execution Environment Defines What the Agent Can Do
+
+Inconsistent results are often blamed on the model, but the cause is frequently an incomplete execution environment. Agents are expected to read/modify files, run build and test commands, call external tools, and use version control. When the environment is misconfigured, you see failures like:
+
+- can't locate the project directory
+- no permission to read or modify files
+- build or test commands fail
+- external tools or services are unreachable
+
+A coding agent depends on three kinds of context:
+
+| Context | What it covers |
+|---------|----------------|
+| Task Context | the prompt and input for the current task |
+| Project Context | repository structure and engineering rules |
+| Environment Context | tools, permissions, and execution environment |
+
+Environment Context determines **what the agent can do, and how far it can go**.
+
+## 6. Involve Coding Agents in the Full Development Loop
+
+A code change is rarely judged on generation alone — it must pass tests, meet standards, and survive review. Bring the agent into the whole loop:
+
+<Steps>
+  <Step title="Implement">Modify or add code per the task.</Step>
+  <Step title="Write/update tests">Add coverage for new behavior or the bug being fixed.</Step>
+  <Step title="Run the test suite">Verify the changes behave as expected.</Step>
+  <Step title="Run checks">Lint, format, and type-check to meet engineering standards.</Step>
+  <Step title="Review the diff">Inspect for regressions and unintended changes.</Step>
+</Steps>
+
+This shifts the agent from a code *generator* to an execution node in the development loop.
+
+## 7. Extend Agent Context with MCP
+
+Much of the context an agent needs lives outside the repo — issue trackers, CI status, database schemas, API docs. Copy-pasting it by hand doesn't scale. The **Model Context Protocol (MCP)** provides a standard way to connect external tools so the agent can retrieve real-time context directly. This expands the agent's context boundary from a repository-level executor to a collaborator that operates within your engineering environment.
+
+## 8. Capture Repeated Workflows as Skills
+
+Some tasks recur constantly — PR review, log analysis, release notes, standard debugging. Describing them from scratch each time is wasteful and inconsistent. Package them as **skills**: structured, reusable workflow templates the agent applies the same way every time.
+
+> If a prompt pattern or task flow is used repeatedly, it should probably be captured as a skill.
+
+## 9. Automate Stable Workflows
+
+Once a skill runs reliably, automate it. Many workflows are repetitive or time-based — commit summaries, investigating failed CI runs, scanning logs, weekly reports. A skill defines *how* a workflow runs; automation defines *when* it runs and how it continues over time. This turns the agent from an interactive tool into a continuous assistant.
+
+## 10. Manage Agent Sessions Deliberately
+
+A session is a working context that accumulates the task objective, relevant code, changes made, and intermediate reasoning. Left unmanaged, unrelated tasks pile up and degrade reasoning quality. Practical habits:
+
+- **One session per task** — keep the working context focused.
+- **Avoid overly long sessions** — summarize or compress when history grows.
+- **Branch explorations get their own session** — don't pile new investigations onto the original.
+- **Periodically compress history** — reduce pressure on the context window.
+
+Session management is a form of context management: a clear session keeps reasoning coherent across multi-step tasks.
+
+## Conclusion
+
+The effectiveness of a coding agent comes from the workflow you build around it: clear task context, planning, captured project rules, a solid execution environment, connected tools, reusable skills, automation, and deliberate session management. Together these turn a code-generation tool into a collaborator across the full development lifecycle.

--- a/en/coding-plan/faq.mdx
+++ b/en/coding-plan/faq.mdx
@@ -1,0 +1,133 @@
+---
+title: "Coding Plan FAQ"
+description: "Frequently asked questions about the Neosantara Coding Plan — quota, billing, tools, and troubleshooting."
+---
+
+## Coding Plan Details
+
+<AccordionGroup>
+  <Accordion title="How much quota does the plan provide?">
+    Each tier has a 5-hour rolling limit and a weekly limit. See the full table in [Quota & Limits](/en/coding-plan/quota-and-limits#plan-tiers). Each prompt typically triggers 15–20 model calls, so the effective monthly allowance far exceeds standard API pricing.
+  </Accordion>
+
+  <Accordion title="Why is my quota consumed faster with top-tier models?">
+    Premium models (e.g. Claude 4.5 Opus, `gemini-3-pro-preview`) consume quota at up to 3× the standard rate when the model is under load. We recommend:
+    - Use lightweight models (Gemini 3 Flash, GLM-4.7 Flash) for routine tasks.
+    - Reserve premium models for complex reasoning and large-scale refactoring.
+  </Accordion>
+
+  <Accordion title="What counts as 1 prompt?">
+    One user turn in your coding tool. Even if the agent makes 15–20 model calls behind the scenes (tool calls, reasoning steps), it counts as a single prompt.
+  </Accordion>
+
+  <Accordion title="What happens when my quota runs out?">
+    Requests are **hard-stopped** until the next 5-hour or weekly window resets. No balance is charged — there is no pay-as-you-go overage. The system will never deduct from your PAYG balance.
+  </Accordion>
+
+  <Accordion title="Which tools are supported?">
+    The Coding Plan works with any tool that supports OpenAI or Anthropic API format:
+    - **Claude Code** (Anthropic mode)
+    - **Cline**, **Continue**, **OpenCode** (OpenAI mode)
+    - **Jelma** (Neosantara's built-in coding agent)
+
+    All supported tools share the same quota under your subscription.
+  </Accordion>
+
+  <Accordion title="Which models are available?">
+    All models on the Neosantara gateway are available, subject to your tier's allowed-model list. This includes Claude, Gemini, GPT, GLM, DeepSeek, and more.
+  </Accordion>
+</AccordionGroup>
+
+## Base URL & Configuration
+
+<AccordionGroup>
+  <Accordion title="Why do I get '403 coding_key_requires_coding_endpoint'?">
+    Coding keys (`nsk_code_*`) only work on the dedicated coding base URLs:
+    - OpenAI-compatible: `https://api.neosantara.xyz/coding/v1`
+    - Anthropic-compatible: `https://api.neosantara.xyz/coding/anthropic`
+
+    If you send a coding key to `/v1` or `/anthropic` (PAYG endpoints), you'll get this error. Update your tool's base URL configuration.
+  </Accordion>
+
+  <Accordion title="Can I use my regular PAYG key on /coding/v1?">
+    A regular PAYG key sent to `/coding/v1` is treated as a normal PAYG request — it works, but it uses your PAYG balance and does **not** consume coding-plan quota. Only coding keys (`nsk_code_*`) draw on the coding-plan quota, and they only work on the coding base URLs.
+  </Accordion>
+
+  <Accordion title="How do I configure Claude Code?">
+    Edit `~/.claude/settings.json`:
+    ```json
+    {
+      "env": {
+        "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+        "ANTHROPIC_AUTH_TOKEN": "nsk_code_YOUR_KEY",
+        "ANTHROPIC_MODEL": "claude-4.5-sonnet"
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="How do I configure Cline / Continue / OpenCode?">
+    Set these in your tool's settings:
+    ```
+    Base URL: https://api.neosantara.xyz/coding/v1
+    API Key:  nsk_code_YOUR_KEY
+    Model:    claude-4.5-sonnet
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Subscription Management
+
+<AccordionGroup>
+  <Accordion title="Does the Coding Plan auto-renew?">
+    **No.** Neosantara Coding Plan is a one-time invoice per period. You'll receive an email reminder 3 days before expiry and can renew from the [Coding Plan dashboard](https://app.neosantara.xyz/coding-plan).
+  </Accordion>
+
+  <Accordion title="How do I renew?">
+    Go to [Coding Plan](https://app.neosantara.xyz/coding-plan) in your dashboard and click "Perpanjang Sekarang" (Renew Now). A new Mayar invoice will be generated.
+  </Accordion>
+
+  <Accordion title="Can I get a refund?">
+    Subscriptions are non-refundable once the invoice is paid. We recommend starting with the Hemat tier to evaluate before upgrading.
+  </Accordion>
+
+  <Accordion title="Can I upgrade my plan mid-cycle?">
+    Yes. Purchase a higher tier — it takes effect immediately. The remaining value of your current plan is not pro-rated (treat it as an early renewal at the higher tier).
+  </Accordion>
+
+  <Accordion title="What happens when my plan expires?">
+    Your coding key will be downgraded to the Free coding tier (if available) or become inactive. PAYG keys and balance are unaffected.
+  </Accordion>
+</AccordionGroup>
+
+## Jelma Integration
+
+<AccordionGroup>
+  <Accordion title="Can I use the Coding Plan with Jelma?">
+    Yes. Jelma is Neosantara's built-in coding agent. Open [Jelma](https://app.neosantara.xyz/jelma) in your dashboard, select a coding agent, and it will use your coding key automatically — no local setup needed.
+  </Accordion>
+
+  <Accordion title="Does Jelma consume the same quota?">
+    Yes. Jelma uses the same prompt-based quota as any other tool connected via your coding key.
+  </Accordion>
+</AccordionGroup>
+
+## Technical Support
+
+<AccordionGroup>
+  <Accordion title="Why am I getting '1113 Insufficient Balance' after purchasing the Coding Plan?">
+    This usually means you're not hitting the correct coding endpoint. Make sure:
+    1. You're using a coding key (`nsk_code_*`), not a regular key.
+    2. Your base URL is `/coding/v1` or `/coding/anthropic`, not `/v1`.
+    3. The model you're calling is in your tier's allowed list.
+
+    The Coding Plan never deducts from PAYG balance. If balance is being deducted, your tool is routing to the wrong endpoint.
+  </Accordion>
+
+  <Accordion title="I subscribed but my key still shows 'Free' tier">
+    Plan activation happens after Mayar confirms payment. If your invoice shows SUCCESS but the tier hasn't updated:
+    1. Wait 1–2 minutes for webhook processing.
+    2. Refresh the Coding Plan page.
+    3. If still not updated, contact support@neosantara.xyz with your invoice ID.
+  </Accordion>
+</AccordionGroup>

--- a/en/coding-plan/faq.mdx
+++ b/en/coding-plan/faq.mdx
@@ -72,9 +72,14 @@ description: "Frequently asked questions about the Neosantara Coding Plan — qu
       "env": {
         "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
         "ANTHROPIC_AUTH_TOKEN": "nsk_code_YOUR_KEY",
-        "ANTHROPIC_MODEL": "claude-4.5-sonnet"
+        "ANTHROPIC_MODEL": "garda-core"
       }
     }
+    ```
+
+    Or use Jelma (no manual config needed):
+    ```bash
+    jelma claude local
     ```
   </Accordion>
 
@@ -83,7 +88,12 @@ description: "Frequently asked questions about the Neosantara Coding Plan — qu
     ```
     Base URL: https://api.neosantara.xyz/coding/v1
     API Key:  nsk_code_YOUR_KEY
-    Model:    claude-4.5-sonnet
+    Model:    garda-core
+    ```
+
+    Or use Jelma:
+    ```bash
+    jelma opencode local
     ```
   </Accordion>
 </AccordionGroup>
@@ -121,6 +131,19 @@ description: "Frequently asked questions about the Neosantara Coding Plan — qu
 
   <Accordion title="Does Jelma consume the same quota?">
     Yes. Jelma uses the same prompt-based quota as any other tool connected via your coding key.
+  </Accordion>
+
+  <Accordion title="How do I use a custom Model Route with Jelma?">
+    Use the `--model` flag with your virtual model name:
+    ```bash
+    jelma claude local --model my-coder
+    jelma codex hetzner --model my-coder
+    ```
+    Jelma sets the virtual name on all model slots, so the gateway resolves every request (main, background, fast) through your failover chain. See [Model Routes](/en/coding-plan/model-routes) for setup.
+  </Accordion>
+
+  <Accordion title="What is garda-core?">
+    `garda-core` is the default model Jelma uses for Coding Plan users. It's a virtual model name that the Neosantara gateway resolves to the best available model on your tier. You can override it with `--model` or by setting a custom [Model Route](/en/coding-plan/model-routes) in your dashboard.
   </Accordion>
 </AccordionGroup>
 

--- a/en/coding-plan/faq.mdx
+++ b/en/coding-plan/faq.mdx
@@ -36,6 +36,18 @@ description: "Frequently asked questions about the Neosantara Coding Plan — qu
   <Accordion title="Which models are available?">
     All models on the Neosantara gateway are available, subject to your tier's allowed-model list. This includes Claude, Gemini, GPT, GLM, DeepSeek, and more.
   </Accordion>
+
+  <Accordion title="Are there concurrency limits?">
+    Yes. The Coding Plan enforces a maximum number of **concurrent in-flight requests** per user (not RPM). This controls how many simultaneous agent calls you can have running at once:
+
+    | Tier | Max concurrent requests |
+    |------|------------------------|
+    | Coding Hemat | 4 |
+    | Coding Reguler | 10 |
+    | Coding Eksklusif | 20 |
+
+    If you exceed the limit, additional requests are rejected until an in-flight request completes. This is separate from the prompt quota — concurrency limits how many requests run *at the same time*, while quota limits the *total* number of prompts per window.
+  </Accordion>
 </AccordionGroup>
 
 ## Base URL & Configuration

--- a/en/coding-plan/faq.mdx
+++ b/en/coding-plan/faq.mdx
@@ -11,7 +11,7 @@ description: "Frequently asked questions about the Neosantara Coding Plan — qu
   </Accordion>
 
   <Accordion title="Why is my quota consumed faster with top-tier models?">
-    Premium models (e.g. Claude 4.5 Opus, `gemini-3-pro-preview`) consume quota at up to 3× the standard rate when the model is under load. We recommend:
+    Premium models (e.g. Claude 4.5 Opus, `gemini-3.5-flash`) consume quota at up to 3× the standard rate when the model is under load. We recommend:
     - Use lightweight models (Gemini 3 Flash, GLM-4.7 Flash) for routine tasks.
     - Reserve premium models for complex reasoning and large-scale refactoring.
   </Accordion>

--- a/en/coding-plan/jelma.mdx
+++ b/en/coding-plan/jelma.mdx
@@ -1,0 +1,118 @@
+---
+title: "Coding Helper (Jelma)"
+description: "Spin up an AI coding agent on your Coding Plan without editing a single config file. Jelma wires the agent to the coding endpoints for you."
+---
+
+**Jelma** is Neosantara's built-in coding helper: it launches any AI coding agent — on your own machine or the cloud — with a single command, all models powered by Neosantara. When you pick the **Coding Plan** billing mode, Jelma automatically points the agent at the coding base URLs (`/coding/v1`, `/coding/anthropic`) using your coding key, so you **never** have to hand-edit `settings.json`, environment variables, or base URLs.
+
+<Note>
+  Jelma is the fastest path to code with the Coding Plan. If you'd rather configure a tool manually, see [Tool Integration](/en/coding-plan/tool-integration).
+</Note>
+
+<Warning>
+  Jelma is **alpha** software. When you run an agent on a cloud, it provisions real cloud resources on your account. Review what it runs and use it at your own risk.
+</Warning>
+
+## Why use Jelma instead of manual setup?
+
+| Manual setup | With Jelma |
+|--------------|-----------|
+| Edit `~/.claude/settings.json` / env vars by hand | Nothing to edit — Jelma injects them |
+| Remember the correct coding base URL per protocol | Selected automatically from your billing mode |
+| Paste your `nsk_code_*` key into each tool | Jelma uses your coding key for you |
+| Repeat for every machine/agent | One command, anywhere |
+
+## Option A — Jelma on the web (zero setup)
+
+The web flow needs **no local installation**. It runs the agent for you and uses your coding key automatically.
+
+<Steps>
+  <Step title="Open Jelma">
+    Go to [Jelma](https://app.neosantara.xyz/jelma) in your dashboard.
+  </Step>
+  <Step title="Choose the Coding Plan billing mode">
+    When prompted **"How do you want to bill this?"**, pick **Coding Plan** (billed by prompt quota, not your PAYG balance). Jelma will use your `nsk_code_*` key.
+
+    <Note>
+      No coding key yet? Create one from the [Coding Plan](https://app.neosantara.xyz/coding-plan) page first, then subscribe to a tier.
+    </Note>
+  </Step>
+  <Step title="Pick a coding agent">
+    Choose from the supported agents (Claude Code, Codex, OpenCode, and more).
+  </Step>
+  <Step title="Pick where to run it">
+    Choose **Your machine** or a cloud provider (AWS, GCP, Hetzner, DigitalOcean, Daytona, E2B, Sprite).
+  </Step>
+  <Step title="Launch">
+    Jelma configures the agent against the coding endpoint and starts it. Begin prompting — quota is drawn from your Coding Plan.
+  </Step>
+</Steps>
+
+## Option B — Jelma CLI
+
+Prefer the terminal? Install the Jelma CLI and let it prompt you for anything it needs.
+
+<Steps>
+  <Step title="Install Jelma">
+    <Tabs>
+      <Tab title="macOS / Linux / WSL">
+        ```bash
+        curl -fsSL https://cli.neosantara.xyz/install.sh | bash
+        ```
+      </Tab>
+      <Tab title="Windows PowerShell">
+        ```powershell
+        irm https://cli.neosantara.xyz/install.ps1 | iex
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+  <Step title="Launch an agent">
+    Run Jelma and choose the **Coding Plan** billing mode when asked. Jelma prompts for anything you skip on first run — including your Neosantara coding key — and saves it to `~/.config/jelma`.
+
+    ```bash
+    jelma
+    ```
+  </Step>
+  <Step title="Provide credentials once">
+    - **Neosantara coding key** (`nsk_code_*`) — powers the models via the coding endpoints.
+    - **Cloud credentials** — only if you chose to run on a cloud (skipped for "Your machine").
+
+    Jelma remembers these for next time, so subsequent launches are a single command.
+  </Step>
+</Steps>
+
+<Tip>
+  In Coding Plan mode, Jelma defaults the agent to `claude-4.5-sonnet` on the coding endpoints. You can switch models anytime — see [Switching Models](/en/coding-plan/switching-models).
+</Tip>
+
+## Supported coding agents
+
+<CardGroup cols={2}>
+  <Card title="Claude Code">Anthropic's agentic coding CLI</Card>
+  <Card title="Codex">OpenAI's coding agent for the terminal</Card>
+  <Card title="OpenClaw">Browser-powered coding TUI with Chrome integration</Card>
+  <Card title="OpenCode">Open-source terminal coding agent</Card>
+  <Card title="KiloCode">Open-source AI coding agent CLI</Card>
+  <Card title="Cursor CLI">Cursor's terminal-based coding agent</Card>
+  <Card title="T3Code">Web GUI for Claude Code and Codex</Card>
+  <Card title="Hermes">Nous Research's agentic CLI</Card>
+  <Card title="Junie">JetBrains' coding agent</Card>
+  <Card title="Pi">Lightweight terminal coding agent</Card>
+</CardGroup>
+
+## Where it can run
+
+`Your machine` · `AWS` · `Google Cloud` · `Hetzner` · `DigitalOcean` · `Daytona` · `E2B` · `Sprite`
+
+## Billing
+
+- In **Coding Plan** mode, every agent Jelma launches bills against your **prompt quota** (5-hour + weekly windows) — not your PAYG balance.
+- All agents connected through Jelma share the same quota under your subscription.
+- Prefer per-token billing? Choose the **Pay-As-You-Go** mode instead; Jelma will use a regular API key on the `/v1` and `/anthropic` endpoints.
+
+## Learn more
+
+- [Jelma on GitHub](https://github.com/neosantara-xyz/jelma)
+- [Coding Plan Overview](/en/coding-plan/overview)
+- [Switching Models](/en/coding-plan/switching-models)

--- a/en/coding-plan/jelma.mdx
+++ b/en/coding-plan/jelma.mdx
@@ -83,7 +83,12 @@ Prefer the terminal? Install the Jelma CLI and let it prompt you for anything it
 </Steps>
 
 <Tip>
-  In Coding Plan mode, Jelma defaults the agent to `claude-4.5-sonnet` on the coding endpoints. You can switch models anytime — see [Switching Models](/en/coding-plan/switching-models).
+  In Coding Plan mode, Jelma defaults the agent to `garda-core` on the coding endpoints. Override with `--model` to use a [Model Route](/en/coding-plan/model-routes) or any model available on your plan:
+
+  ```bash
+  jelma claude local --model josjis   # Use your custom route "josjis"
+  jelma codex local --model deepseek-v4-flash
+  ```
 </Tip>
 
 ## Supported coding agents

--- a/en/coding-plan/learning-path.mdx
+++ b/en/coding-plan/learning-path.mdx
@@ -1,0 +1,43 @@
+---
+title: "Learning Path"
+description: "Start here — the fastest route through the Neosantara Coding Plan, from subscribing to optimizing quota."
+---
+
+New to the Coding Plan? Follow the path below. Already know what you need? Jump ahead with the shortcut cards.
+
+## Start Here
+
+<Steps>
+  <Step title="Subscribe & get a coding key">
+    Pick a tier and create a `nsk_code_*` key. See the [Overview](/en/coding-plan/overview) for how the plan works.
+  </Step>
+  <Step title="Connect a tool">
+    Wire up your coding agent — [Tool Integration](/en/coding-plan/tool-integration) for Claude Code, Cline, Continue, OpenCode, or Cursor. Prefer zero setup? Use [Jelma](/en/coding-plan/jelma).
+  </Step>
+  <Step title="Send your first prompt">
+    Follow the [Quick Start](/en/coding-plan/quick-start) to verify your setup and start coding.
+  </Step>
+  <Step title="Understand your quota">
+    Learn how prompts, windows, and multipliers work in [Quota & Limits](/en/coding-plan/quota-and-limits).
+  </Step>
+  <Step title="Optimize">
+    Switch models per task to conserve quota — see [Switching Models](/en/coding-plan/switching-models).
+  </Step>
+</Steps>
+
+## Shortcuts
+
+<CardGroup cols={2}>
+  <Card title="Zero setup" href="/en/coding-plan/jelma">
+    Launch an agent with no config using Jelma.
+  </Card>
+  <Card title="I use Claude Code / Cline / Cursor" href="/en/coding-plan/tool-integration">
+    Manual configuration for supported tools.
+  </Card>
+  <Card title="Minimize quota burn" href="/en/coding-plan/quota-and-limits">
+    Quota rules plus model-switching strategy.
+  </Card>
+  <Card title="Rules & fair use" href="/en/coding-plan/usage-policy">
+    What's allowed and how limits are enforced.
+  </Card>
+</CardGroup>

--- a/en/coding-plan/memory-mechanism.mdx
+++ b/en/coding-plan/memory-mechanism.mdx
@@ -1,0 +1,157 @@
+---
+title: "Memory Mechanism"
+description: "How coding agents retain context across tasks and sessions — memory types, the retrieve-assemble-update pattern, layered memory, and troubleshooting."
+---
+
+Memory lets a coding agent retain context across tasks and sessions, reducing repeated input and improving efficiency. With a good memory design, an agent keeps understanding the project structure, engineering conventions, and your preferences, and reuses that information in later work. Memory is usually organized into layers such as session, project, and long-term memory.
+
+## Why Coding Agents Need Memory
+
+Language models do not preserve state between calls on their own. They can't remember project context across sessions, accumulate experience, or consistently adapt to your preferences. Agent systems solve this with **external memory**. A typical loop looks like this:
+
+```text
+User input
+   ↓
+Memory retrieval
+   ↓
+Context assembly
+   ↓
+Model reasoning
+   ↓
+Action / tool call
+   ↓
+Memory update
+```
+
+The agent retrieves relevant memory before a task and updates memory after it — a common pattern in modern agent systems.
+
+## Memory Architecture
+
+At a high level:
+
+```text
+Short-term memory
+    └ session context
+
+Long-term memory
+    ├ semantic memory
+    ├ episodic memory
+    └ procedural memory
+```
+
+## Core Memory Types
+
+<AccordionGroup>
+  <Accordion title="Session memory">
+    Context tied to the current task — conversation history, recent tool outputs, the current plan, and files in scope. Usually lives in the model's context window.
+  </Accordion>
+  <Accordion title="Project memory">
+    Long-lived information about the whole codebase — architecture, coding standards, build workflows, common commands. Typically written into `.md` files and loaded at the start of a session.
+  </Accordion>
+  <Accordion title="Semantic memory">
+    Factual knowledge and reference material — API docs, language rules, knowledge bases. Often implemented with retrieval-augmented generation (RAG): embed the query, search a vector store, retrieve documents, then reason.
+  </Accordion>
+  <Accordion title="Episodic memory">
+    Records of past experiences — how a previous bug was fixed, the root cause of a build failure, a debugging strategy that worked. Helps the agent learn from prior work.
+  </Accordion>
+  <Accordion title="Procedural memory">
+    Step-by-step workflows for completing tasks — e.g. a debugging routine: read the error log, locate the file, write the patch, run tests. Used in prompt engineering, workflow templates, and policies.
+  </Accordion>
+</AccordionGroup>
+
+## The Standard Memory Pattern
+
+<Steps>
+  <Step title="Memory retrieval">
+    Before a task, the agent retrieves relevant project memory, knowledge-base entries, and prior experience, then injects them into the working context.
+  </Step>
+  <Step title="Context construction">
+    Retrieved memories are assembled into a complete context and passed to the model.
+  </Step>
+  <Step title="Memory update">
+    After the task, the agent decides whether to write new memories — newly discovered rules, debugging experience, or preferences.
+  </Step>
+</Steps>
+
+## Using Memory Correctly
+
+Effective memory is **layered, controllable, retrievable, and updatable**. Rather than expecting the model to "remember everything," establish a clear pattern for what goes where.
+
+### Separate instruction memory from learning memory
+
+- **Instruction memory** is written by humans to tell the agent how to work — coding standards, directory conventions, build/test commands, naming, commit rules, safety rules.
+- **Learning memory** is accumulated over time from your corrections, preferences, failed attempts, and habits.
+
+Mixing them causes behavior to drift. Write **rules and constraints** into instruction memory (stable, predictable), and **experience and preferences** into learning memory (improves over time). Keeping them separate stops experience notes from polluting core rules.
+
+### Layered memory management
+
+| Layer | Scope | Examples |
+|-------|-------|----------|
+| Organization | all developers/projects | security & compliance, review standards, restricted directories, dependency/license constraints |
+| Project | team-shared, version-controlled | architecture, directory conventions, build/test commands, naming, workflows |
+| User | personal, across projects | preferred style, debugging sequence, output format, shortcuts |
+| Local | this machine, not committed | test accounts, local ports, mock endpoints, machine-specific notes |
+| Role / agent | one specialized agent | test commands for a testing agent, module boundaries for a refactoring agent |
+
+Organization memory is the highest-priority governance layer and should not be casually bypassed. Project memory is the most important shared layer.
+
+### Load `.md` files by path
+
+For large repositories, split instructions into multiple topic-focused Markdown files (e.g. `testing.md`, `api-design.md`, `security.md`) and load them by path only when relevant. Three principles:
+
+- Keep the main memory file limited to global shared context.
+- Keep specialized rules modular — one topic per file.
+- If a rule can be loaded by path, don't load it globally; bring it in only when needed.
+
+A memory structure might look like this:
+
+```text
+agent-memory/
+├── project.md            # Project overview
+├── rules/
+│   ├── code-style.md     # Code style
+│   ├── testing.md        # Testing conventions
+│   ├── api-design.md     # API design guidelines
+│   ├── security.md       # Security requirements
+│   └── frontend/
+│       └── react.md      # Frontend-specific rules
+└── local/
+    └── developer.local.md
+```
+
+### Write memory rules as concrete instructions
+
+Use specific, verifiable rules rather than vague principles. Prefer:
+
+- Use 2-space indentation in all new TypeScript files.
+- Run `pnpm test` after modifying business logic.
+- Place all API handlers under `src/api/handlers/`.
+- Keep page components under 300 lines; split larger ones into hooks or child components.
+
+Over vague statements like "keep the code clean" or "write good tests." Keep the main memory file concise (ideally under ~200 lines) and use Markdown headings and lists.
+
+### Separate shared rules from personal preferences
+
+Define each rule's scope and owner: project (team, version-controlled), organization (central IT/DevOps), user (individual), local (single machine), role (a specialized agent). The guiding question is: **who owns it, who shares it, and who it applies to.** Clear boundaries prevent rule sprawl and duplicate definitions.
+
+### Reuse memory through imports and rule packages
+
+Many rules are shared conventions across repositories. Rewriting them everywhere invites inconsistency. Where the tooling supports it, import shared rule files or link a shared rules directory, and build reusable rule packages (e.g. security rules, frontend rules, testing rules). Each project references only the modules it needs, so rules are maintained centrally and applied consistently.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="The agent isn't following my .md memory files">
+    `.md` files are contextual instructions, not enforced configuration. The agent tries to follow them but can't guarantee compliance when rules are vague or conflicting. Confirm the files loaded, that they're in an allowed path/scope, and that no two files give conflicting instructions for the same behavior.
+  </Accordion>
+  <Accordion title="I don't know what auto-memory has saved">
+    Many agents keep background auto-memory as Markdown files. Use the tool's memory command to view the memory directory, then read, edit, or delete those files directly.
+  </Accordion>
+  <Accordion title="My memory files are too large">
+    Oversized files consume context window, reduce adherence, and increase conflicts. Split detailed content into multiple Markdown files and reference or import them, or move rules into a dedicated `rules/` directory.
+  </Accordion>
+  <Accordion title="Instructions disappear after context compression">
+    Long conversations get compressed. Memory files are typically reloaded from disk afterward, so only content written into files persists. If a rule disappears after compression, it lived only in the conversation. Write long-term instructions into `.md` files instead of relying on the conversation.
+  </Accordion>
+</AccordionGroup>

--- a/en/coding-plan/model-routes.mdx
+++ b/en/coding-plan/model-routes.mdx
@@ -31,34 +31,7 @@ my-coder → claude-4.5-sonnet (primary)
 
 ## Managing Routes
 
-### Via Dashboard
-
 Open [Coding Plan](https://app.neosantara.xyz/coding-plan) in your dashboard. The **Model Routes** section lets you create, edit, and delete routes visually.
-
-### Via API
-
-**List routes:**
-```bash bash
-curl https://api.neosantara.xyz/v1/coding/model-routes \
-  -H "Authorization: Bearer nsk_code_YOUR_KEY"
-```
-
-**Create/update a route:**
-```bash bash
-curl -X POST https://api.neosantara.xyz/v1/coding/model-routes \
-  -H "Authorization: Bearer nsk_code_YOUR_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "virtual_name": "my-coder",
-    "model_chain": ["claude-4.5-sonnet", "gemini-3-flash"]
-  }'
-```
-
-**Delete a route:**
-```bash bash
-curl -X DELETE https://api.neosantara.xyz/v1/coding/model-routes/ROUTE_ID \
-  -H "Authorization: Bearer nsk_code_YOUR_KEY"
-```
 
 ## Rules
 

--- a/en/coding-plan/model-routes.mdx
+++ b/en/coding-plan/model-routes.mdx
@@ -1,0 +1,93 @@
+---
+title: "Model Routes"
+description: "Create virtual model aliases with fallback chains — map a custom name to a sequence of models that fail over automatically."
+---
+
+**Model Routes** let you define custom model aliases that resolve to a chain of real models. When the primary model is unavailable (rate-limited or erroring), the request automatically falls through to the next model in the chain — no client-side retry logic needed.
+
+<Note>
+  Model Routes require an **active Coding Plan** (paid subscription or trial). They only take effect on requests made with a coding key (`nsk_code_*`) through the coding endpoints.
+</Note>
+
+## How It Works
+
+1. You create a virtual name (e.g. `my-coder`) and assign it a model chain (e.g. `["claude-4.5-sonnet", "gemini-3-flash"]`).
+2. When you send a request with `model: "my-coder"` on the coding endpoint, the system tries the first model in the chain.
+3. If the first model fails (capacity error), it automatically tries the next model, and so on.
+
+```text
+my-coder → claude-4.5-sonnet (primary)
+              ↓ (capacity error)
+           gemini-3-flash (fallback)
+```
+
+## Limits
+
+| Tier | Max models per chain | Max routes per user |
+|------|---------------------|---------------------|
+| Coding Hemat | 3 | 10 |
+| Coding Reguler | 5 | 10 |
+| Coding Eksklusif | 8 | 10 |
+
+## Managing Routes
+
+### Via Dashboard
+
+Open [Coding Plan](https://app.neosantara.xyz/coding-plan) in your dashboard. The **Model Routes** section lets you create, edit, and delete routes visually.
+
+### Via API
+
+**List routes:**
+```bash bash
+curl https://api.neosantara.xyz/v1/coding/model-routes \
+  -H "Authorization: Bearer nsk_code_YOUR_KEY"
+```
+
+**Create/update a route:**
+```bash bash
+curl -X POST https://api.neosantara.xyz/v1/coding/model-routes \
+  -H "Authorization: Bearer nsk_code_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "virtual_name": "my-coder",
+    "model_chain": ["claude-4.5-sonnet", "gemini-3-flash"]
+  }'
+```
+
+**Delete a route:**
+```bash bash
+curl -X DELETE https://api.neosantara.xyz/v1/coding/model-routes/ROUTE_ID \
+  -H "Authorization: Bearer nsk_code_YOUR_KEY"
+```
+
+## Rules
+
+- Virtual names cannot conflict with existing real model IDs (e.g. you can't name a route `claude-4.5-sonnet`).
+- Virtual names are case-insensitive and unique per user.
+- Every model in the chain must be available on your coding plan tier.
+- Virtual name max length: 100 characters.
+
+## Using a Route in Your Tool
+
+Once created, use the virtual name anywhere you'd specify a model:
+
+**Claude Code** (`~/.claude/settings.json`):
+```json json
+{
+  "env": {
+    "ANTHROPIC_MODEL": "my-coder"
+  }
+}
+```
+
+**Cline / Continue / OpenCode:**
+```text
+Model: my-coder
+```
+
+The coding endpoint resolves `my-coder` → your chain → first available model, transparently.
+
+## Related
+
+- [Switching Models](/en/coding-plan/switching-models) — pick models per task.
+- [Quota & Limits](/en/coding-plan/quota-and-limits) — how multipliers work per model.

--- a/en/coding-plan/model-routes.mdx
+++ b/en/coding-plan/model-routes.mdx
@@ -44,6 +44,14 @@ Open [Coding Plan](https://app.neosantara.xyz/coding-plan) in your dashboard. Th
 
 Once created, use the virtual name anywhere you'd specify a model:
 
+**Jelma CLI** (recommended — zero config):
+```bash
+jelma claude local --model my-coder
+jelma codex hetzner --model my-coder
+```
+
+Jelma passes the virtual name to both the agent's model flag and the settings file, so all model slots (main, background, fast) route through your chain.
+
 **Claude Code** (`~/.claude/settings.json`):
 ```json json
 {

--- a/en/coding-plan/overview.mdx
+++ b/en/coding-plan/overview.mdx
@@ -1,0 +1,90 @@
+---
+title: "Overview"
+description: "Flat-fee subscription built for AI coding agents. Prompt-based quota, no overage, no auto-renew."
+---
+
+The **Neosantara Coding Plan** is a subscription designed specifically for AI-powered coding workflows. It works with coding tools like **Neo Code**, **Claude Code**, **Cline**, and **OpenCode**.
+
+<Note>
+  The Coding Plan uses **dedicated base URLs** (`/coding/v1` and `/coding/anthropic`). Coding keys (`nsk_code_*`) **cannot** be used on the regular PAYG endpoints (`/v1`, `/anthropic`) — they are rejected with `403`. A regular PAYG key sent to a coding base URL is simply treated as a normal PAYG request and does **not** consume coding-plan quota.
+</Note>
+
+## How It Works
+
+| Concept | Detail |
+|---------|--------|
+| **1 prompt** | 1 user turn in your coding tool — may trigger ~15–20 model calls under the hood (agent loop) |
+| **Quota windows** | 5-hour rolling + weekly. Resets automatically. |
+| **Overage** | None. Requests are hard-stopped until the window resets. |
+| **Auto-renew** | No. You receive a reminder 3 days before expiry and can renew from the dashboard. |
+
+## Dedicated Base URLs
+
+Coding keys (`nsk_code_*`) only work on the coding base paths:
+
+| Protocol | Base URL |
+|----------|----------|
+| OpenAI-compatible | `https://api.neosantara.xyz/coding/v1` |
+| Anthropic-compatible | `https://api.neosantara.xyz/coding/anthropic` |
+
+<Warning>
+  Coding keys sent to the regular `/v1` or `/anthropic` endpoints will receive a `403 coding_key_requires_coding_endpoint` error.
+</Warning>
+
+## Quick Start
+
+<Steps>
+  <Step title="Create a Coding Key">
+    Go to [Coding Plan](https://app.neosantara.xyz/coding-plan) or [API Keys](https://app.neosantara.xyz/api-keys) and create a key with the `[CODE]` prefix.
+  </Step>
+  <Step title="Subscribe to a Plan">
+    Choose a tier (Hemat / Reguler / Eksklusif) and complete the Mayar invoice payment.
+  </Step>
+  <Step title="Configure Your Tool">
+    Point your coding agent at the coding base URL with your coding key.
+
+    **Claude Code** (`~/.claude/settings.json`):
+    ```json
+    {
+      "env": {
+        "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+        "ANTHROPIC_AUTH_TOKEN": "nsk_code_YOUR_KEY_HERE",
+        "ANTHROPIC_MODEL": "claude-4.5-sonnet"
+      }
+    }
+    ```
+
+    **Cline / Continue / OpenCode** (OpenAI mode):
+    ```
+    Base URL: https://api.neosantara.xyz/coding/v1
+    API Key:  nsk_code_YOUR_KEY_HERE
+    Model:    claude-4.5-sonnet
+    ```
+  </Step>
+  <Step title="Or Use Jelma">
+    Open [Jelma](https://app.neosantara.xyz/jelma) in your dashboard to spawn a Neosantara coding agent directly — no local setup needed.
+  </Step>
+</Steps>
+
+## Quota & Limits
+
+Quota is prompt-based: **1 prompt = 1 user turn**, regardless of how many model calls the agent makes internally. There is no overage — when a window's quota runs out, requests are blocked until it resets.
+
+See [Quota & Limits](/en/coding-plan/quota-and-limits) for the full tier pricing table, 5-hour/weekly windows, and load-based model multipliers.
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Does the Coding Plan auto-renew?">
+    No. It's a one-time invoice per period. You'll get an email reminder 3 days before expiry.
+  </Accordion>
+  <Accordion title="What happens when quota runs out?">
+    Requests are blocked (hard-stop) until the next 5-hour or weekly window resets. No balance is charged.
+  </Accordion>
+  <Accordion title="Can I use my coding key on regular /v1 endpoints?">
+    No. Coding keys only work on `/coding/v1` and `/coding/anthropic`. Regular PAYG keys work on `/v1` and `/anthropic`.
+  </Accordion>
+  <Accordion title="Which models are available?">
+    All models available on the Neosantara gateway, subject to your tier's allowed-model list.
+  </Accordion>
+</AccordionGroup>

--- a/en/coding-plan/quick-start.mdx
+++ b/en/coding-plan/quick-start.mdx
@@ -1,0 +1,144 @@
+---
+title: "Quick Start"
+description: "Get started with the Neosantara Coding Plan in minutes — from subscribing to coding with AI agents."
+---
+
+This guide will help you get started with the [Neosantara Coding Plan](/en/coding-plan/overview) in minutes — from subscribing to using models in supported coding tools.
+
+## Getting Started
+
+<Steps>
+  <Step title="Register or Login">
+    Access the [Neosantara Dashboard](https://app.neosantara.xyz) and register or login.
+  </Step>
+
+  <Step title="Subscribe to a Coding Plan">
+    Navigate to the [Coding Plan](https://app.neosantara.xyz/coding-plan) page and choose your tier:
+
+    | Tier | 5-Hour Limit | Weekly Limit | Price |
+    |------|--------------|--------------|-------|
+    | Coding Hemat | ~80 prompts | ~400 prompts | Rp 149.000/mo |
+    | Coding Reguler | ~400 prompts | ~2.000 prompts | Rp 499.000/mo |
+    | Coding Eksklusif | ~1.600 prompts | ~8.000 prompts | Rp 1.290.000/mo |
+
+    Complete the Mayar invoice payment. Your plan activates within 1–2 minutes.
+  </Step>
+
+  <Step title="Obtain a Coding Key">
+    After subscribing, create a coding key from the [Coding Plan](https://app.neosantara.xyz/coding-plan) page or the [API Keys](https://app.neosantara.xyz/api-keys) page. Your key will look like `nsk_code_...`.
+
+    <Warning>
+      Safeguard your coding key. It cannot be displayed again after creation.
+    </Warning>
+  </Step>
+
+  <Step title="Connect a Coding Tool">
+    The Neosantara Coding Plan works with any tool that supports OpenAI or Anthropic API format. Click a tool below to jump to its configuration:
+
+    <CardGroup cols={3}>
+      <Card title="Claude Code" href="#claude-code">CLI agent by Anthropic</Card>
+      <Card title="Cline" href="#cline">VS Code extension</Card>
+      <Card title="Continue" href="#continue-opencode">VS Code / JetBrains</Card>
+      <Card title="OpenCode" href="#continue-opencode">Terminal agent</Card>
+      <Card title="Cursor" href="#cursor">AI-first editor</Card>
+      <Card title="Jelma" href="#jelma">Neosantara built-in (no setup)</Card>
+    </CardGroup>
+  </Step>
+
+  <Step title="Endpoint Guide">
+    Neosantara Coding Plan supports both Anthropic and OpenAI protocols. Use the correct **coding base URL**:
+
+    | Protocol | Base URL |
+    |----------|----------|
+    | Anthropic Messages | `https://api.neosantara.xyz/coding/anthropic` |
+    | OpenAI Chat Completions | `https://api.neosantara.xyz/coding/v1` |
+
+    <Warning>
+      Using the wrong endpoint (e.g. `/v1` instead of `/coding/v1`) will result in a `403 coding_key_requires_coding_endpoint` error.
+    </Warning>
+  </Step>
+
+  <Step title="Start Coding">
+    Once configured, begin coding with AI:
+
+    <Tabs>
+      <Tab title="Natural Language Programming">
+        ```
+        # Describe what you want
+        Create a React component with a login form that validates email and password
+        ```
+      </Tab>
+      <Tab title="Code Debugging">
+        ```
+        # Describe the issue
+        My API request returns a 404 error. Check the routing configuration.
+        ```
+      </Tab>
+      <Tab title="Code Optimization">
+        ```
+        # Ask for improvements
+        This function has O(n²) complexity. Optimize it to O(n log n).
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+</Steps>
+
+## Tool Configuration
+
+### Claude Code
+
+Edit `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "nsk_code_YOUR_KEY",
+    "ANTHROPIC_MODEL": "claude-4.5-sonnet",
+    "ANTHROPIC_SMALL_FAST_MODEL": "gemini-3-flash",
+    "API_TIMEOUT_MS": "3600000"
+  }
+}
+```
+
+Verify with `/status` — confirm the model and base URL are correct.
+
+### Cline
+
+In VS Code, open Cline settings:
+1. **API Provider**: Select `OpenAI Compatible`
+2. **Base URL**: `https://api.neosantara.xyz/coding/v1`
+3. **API Key**: `nsk_code_YOUR_KEY`
+4. **Model**: Enter `claude-4.5-sonnet` (or any supported model)
+
+### Continue / OpenCode
+
+```yaml
+# ~/.continue/config.yaml or tool settings
+provider: openai-compatible
+baseUrl: https://api.neosantara.xyz/coding/v1
+apiKey: nsk_code_YOUR_KEY
+model: claude-4.5-sonnet
+```
+
+### Cursor
+
+1. Open Settings → Models → Add Model
+2. **Base URL**: `https://api.neosantara.xyz/coding/v1`
+3. **API Key**: `nsk_code_YOUR_KEY`
+4. **Model**: `claude-4.5-sonnet`
+
+### Jelma
+
+No configuration needed. Open [Jelma](https://app.neosantara.xyz/jelma) in your dashboard, select a coding agent, and start coding. Jelma uses your coding key automatically.
+
+## Tips for Efficient Quota Usage
+
+<Tip>
+  **Use lightweight models for routine tasks.** `gemini-3-flash` and `glm-4.7-flash` consume 1× quota; flagship models cost more (up to 3× under load). See [Quota & Limits](/en/coding-plan/quota-and-limits) for the full multiplier table.
+</Tip>
+
+- **1 prompt = 1 user turn** — regardless of how many model calls the agent makes internally (~15–20 calls per turn is typical).
+- **Quota resets automatically** on 5-hour rolling and weekly windows.
+- **No overage** — when quota runs out, requests are blocked until the next window. No balance is charged.

--- a/en/coding-plan/quota-and-limits.mdx
+++ b/en/coding-plan/quota-and-limits.mdx
@@ -1,0 +1,65 @@
+---
+title: "Quota & Limits"
+description: "How the Neosantara Coding Plan quota works — prompts, 5-hour and weekly windows, tier limits, and load-based model multipliers."
+---
+
+This is the canonical reference for how quota is measured and consumed on the [Coding Plan](/en/coding-plan/overview).
+
+## What Counts as 1 Prompt
+
+Quota is **prompt-based, not token-based**. One prompt = **one user turn** in your coding tool — no matter how many model calls the agent makes under the hood.
+
+<Info>
+  A single "fix this bug" turn may trigger ~15–20 model calls internally (reasoning steps, tool calls, file reads). That entire turn still counts as **1 prompt**.
+</Info>
+
+**Worked example:** You ask your agent to *"refactor this module and update the tests."* The agent reads 6 files, runs the test suite twice, and makes 18 model calls to complete the task. Your quota decreases by **1 prompt** (times the model multiplier — see below).
+
+## Quota Windows
+
+| Window | Behavior |
+|--------|----------|
+| **5-hour rolling** | Resets automatically 5 hours after use begins. |
+| **Weekly** | Resets 7 days from your subscription start. |
+
+- **No overage.** When a window's quota is exhausted, requests are hard-stopped until it resets.
+- **No balance deduction.** The Coding Plan never charges your PAYG balance.
+
+## Plan Tiers
+
+| Tier | 5-Hour Limit | Weekly Limit | Price |
+|------|--------------|--------------|-------|
+| Coding Hemat | ~80 prompts | ~400 prompts | Rp 149.000/mo |
+| Coding Reguler | ~400 prompts | ~2.000 prompts | Rp 499.000/mo |
+| Coding Eksklusif | ~1.600 prompts | ~8.000 prompts | Rp 1.290.000/mo |
+
+<Info>
+  Actual available usage varies with project complexity and model choice.
+</Info>
+
+## Load-Based Model Multipliers
+
+Each prompt consumes quota equal to its model's multiplier. Flagship models cost more when the upstream is **under load**. Load is detected **dynamically per model** from its live capacity-error rate over a rolling window — it is **not** a fixed time-of-day schedule.
+
+| Condition | Flagship models | Mid-tier models | Lightweight models |
+|-----------|-----------------|-----------------|--------------------|
+| Normal | 2× | 2× | 1× |
+| Under load | 3× | 2× | 1× |
+
+<Note>
+  Only flagship-band models switch between 2× and 3×. Mid-tier stays at 2× and lightweight stays at 1× regardless of load. "Under load" is derived from each model's live upstream capacity, not a wall-clock window.
+</Note>
+
+## Tips to Conserve Quota
+
+<Tip>
+  Use lightweight models (`gemini-3-flash`, `glm-4.7-flash`) for routine tasks — they stay at 1×. Reserve flagship models (`claude-4.5-sonnet`, `claude-4.5-opus`) for complex reasoning and large refactors.
+</Tip>
+
+- Batch related changes into a single turn where practical — fewer turns, fewer prompts.
+- Switch models per task instead of running everything on a flagship. See [Switching Models](/en/coding-plan/switching-models).
+
+## Related
+
+- [Switching Models](/en/coding-plan/switching-models) — pick the right model per task.
+- [Usage Policy](/en/coding-plan/usage-policy) — rate-limit enforcement and fair use.

--- a/en/coding-plan/switching-models.mdx
+++ b/en/coding-plan/switching-models.mdx
@@ -1,0 +1,101 @@
+---
+title: "Switching Models"
+description: "How to switch between models in your coding tool when using the Neosantara Coding Plan."
+---
+
+The Neosantara Coding Plan gives you access to all models on the gateway. You can switch models at any time without changing your subscription.
+
+## Before You Start
+
+Make sure you have:
+1. An **active Coding Plan subscription** and a valid coding key (`nsk_code_*`).
+2. The **correct coding endpoint** configured in your tool.
+3. A working basic setup (test with a simple prompt first).
+
+## Available Models
+
+All models on the Neosantara gateway are available through the Coding Plan. Popular choices for coding:
+
+| Model | Best for | Quota multiplier |
+|-------|----------|-----------------|
+| `claude-4.5-sonnet` | Complex coding, refactoring | 2× (normal), 3× (under load) |
+| `claude-4.5-opus` | Deep reasoning, architecture | 2× (normal), 3× (under load) |
+| `gemini-3-flash` | Fast iteration, routine tasks | 1× |
+| `glm-4.7-flash` | Budget-friendly daily coding | 1× |
+| `deepseek-r1` | Reasoning-heavy tasks | 1× |
+| `qwen3-32b` | Multi-language support | 1× |
+
+<Tip>
+  Use lightweight models (`gemini-3-flash`, `glm-4.7-flash`) for routine tasks and switch to premium models only for complex reasoning — this maximizes your quota.
+</Tip>
+
+## Switching Models in Claude Code
+
+### Method 1: Update settings.json
+
+Edit `~/.claude/settings.json` and change the model environment variables:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "nsk_code_YOUR_KEY",
+    "ANTHROPIC_MODEL": "deepseek-r1",
+    "ANTHROPIC_SMALL_FAST_MODEL": "gemini-3-flash",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-4.5-sonnet",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-4.5-opus",
+    "API_TIMEOUT_MS": "3600000"
+  }
+}
+```
+
+### Method 2: Use /model command
+
+In an active Claude Code session, type:
+
+```
+/model claude-4.5-opus
+```
+
+This switches the model for the current session without editing config files.
+
+### Verify the switch
+
+Type `/status` in Claude Code to confirm the active model.
+
+## Switching Models in Cline
+
+1. Open Cline settings in VS Code
+2. Under **Model**, change the model name (e.g. `gemini-3-flash`)
+3. The change takes effect immediately for new messages
+
+## Switching Models in Continue / OpenCode
+
+Update the `model` field in your configuration:
+
+```
+Base URL: https://api.neosantara.xyz/coding/v1
+API Key:  nsk_code_YOUR_KEY
+Model:    gemini-3-flash
+```
+
+## Switching Models in Cursor
+
+1. Settings → Models
+2. Change the model name in your custom model configuration
+3. Or add multiple model entries and select between them in the chat
+
+## Model Recommendations by Task
+
+| Task | Recommended Model | Why |
+|------|-------------------|-----|
+| Quick fixes, linting | `gemini-3-flash` | Fast, cheap (1× quota) |
+| Feature implementation | `claude-4.5-sonnet` | Best balance of speed and quality |
+| Complex refactoring | `claude-4.5-opus` | Deep reasoning capability |
+| Debugging with context | `deepseek-r1` | Strong at tracing logic |
+| Code review | `qwen3-32b` | Good at explanations |
+| Routine boilerplate | `glm-4.7-flash` | Fast and free-tier friendly |
+
+## Load-Based Quota Multipliers
+
+Model multipliers (1× lightweight, 2× mid/flagship, up to 3× for flagship under load) determine how much quota each prompt costs. See [Quota & Limits](/en/coding-plan/quota-and-limits#load-based-model-multipliers) for the full breakdown.

--- a/en/coding-plan/switching-models.mdx
+++ b/en/coding-plan/switching-models.mdx
@@ -3,7 +3,7 @@ title: "Switching Models"
 description: "How to switch between models in your coding tool when using the Neosantara Coding Plan."
 ---
 
-The Neosantara Coding Plan gives you access to all models on the gateway. You can switch models at any time without changing your subscription.
+The Neosantara Coding Plan gives you access to models on the gateway based on your tier. You can switch models at any time without changing your subscription.
 
 ## Before You Start
 
@@ -12,39 +12,56 @@ Make sure you have:
 2. The **correct coding endpoint** configured in your tool.
 3. A working basic setup (test with a simple prompt first).
 
-## Available Models
+## Check Available Models
 
-All models on the Neosantara gateway are available through the Coding Plan. Popular choices for coding:
+Available models depend on your tier and can change at any time. Check your current allowed models:
 
-| Model | Best for | Quota multiplier |
-|-------|----------|-----------------|
-| `claude-4.5-sonnet` | Complex coding, refactoring | 2× (normal), 3× (under load) |
-| `claude-4.5-opus` | Deep reasoning, architecture | 2× (normal), 3× (under load) |
-| `gemini-3-flash` | Fast iteration, routine tasks | 1× |
-| `glm-4.7-flash` | Budget-friendly daily coding | 1× |
-| `deepseek-r1` | Reasoning-heavy tasks | 1× |
-| `qwen3-32b` | Multi-language support | 1× |
+**From the dashboard:**
+Open [Coding Plan](https://app.neosantara.xyz/coding-plan) → the "Overview" tab shows your allowed models.
 
-<Tip>
-  Use lightweight models (`gemini-3-flash`, `glm-4.7-flash`) for routine tasks and switch to premium models only for complex reasoning — this maximizes your quota.
-</Tip>
+**From the CLI:**
+```bash
+jelma models
+```
+
+**From the API:**
+```bash
+curl https://api.neosantara.xyz/coding/v1/models \
+  -H "Authorization: Bearer nsk_code_YOUR_KEY"
+```
+
+<Note>
+  An empty allowed-models list means **all models** on the gateway are available. Higher tiers unlock more models, including frontier models with higher quota multipliers.
+</Note>
 
 ## Switching Models in Claude Code
 
 ### Method 1: Update settings.json
 
-Edit `~/.claude/settings.json` and change the model environment variables:
+Edit `~/.claude/settings.json` and change the model:
 
 ```json
 {
   "env": {
     "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
     "ANTHROPIC_AUTH_TOKEN": "nsk_code_YOUR_KEY",
-    "ANTHROPIC_MODEL": "deepseek-r1",
-    "ANTHROPIC_SMALL_FAST_MODEL": "gemini-3-flash",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-4.5-sonnet",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-4.5-opus",
-    "API_TIMEOUT_MS": "3600000"
+    "ANTHROPIC_MODEL": "garda-core"
+  }
+}
+```
+
+Claude Code uses multiple model slots. Override all of them to ensure every request routes through your chosen model (or your [Model Route](/en/coding-plan/model-routes)):
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "nsk_code_YOUR_KEY",
+    "ANTHROPIC_MODEL": "garda-core",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "garda-core",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "garda-core",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "garda-core",
+    "ANTHROPIC_SMALL_FAST_MODEL": "garda-core"
   }
 }
 ```
@@ -54,10 +71,18 @@ Edit `~/.claude/settings.json` and change the model environment variables:
 In an active Claude Code session, type:
 
 ```
-/model claude-4.5-opus
+/model deepseek-v4-flash
 ```
 
 This switches the model for the current session without editing config files.
+
+### Method 3: Use Jelma
+
+Jelma sets all model slots automatically:
+
+```bash
+jelma claude local --model deepseek-v4-flash
+```
 
 ### Verify the switch
 
@@ -66,7 +91,7 @@ Type `/status` in Claude Code to confirm the active model.
 ## Switching Models in Cline
 
 1. Open Cline settings in VS Code
-2. Under **Model**, change the model name (e.g. `gemini-3-flash`)
+2. Under **Model**, change the model name
 3. The change takes effect immediately for new messages
 
 ## Switching Models in Continue / OpenCode
@@ -76,7 +101,20 @@ Update the `model` field in your configuration:
 ```
 Base URL: https://api.neosantara.xyz/coding/v1
 API Key:  nsk_code_YOUR_KEY
-Model:    gemini-3-flash
+Model:    deepseek-v4-flash
+```
+
+## Switching Models in Codex CLI
+
+Edit `~/.codex/config.toml`:
+
+```toml
+model = "deepseek-v4-flash"
+```
+
+Or use Jelma:
+```bash
+jelma codex local --model deepseek-v4-flash
 ```
 
 ## Switching Models in Cursor
@@ -85,17 +123,28 @@ Model:    gemini-3-flash
 2. Change the model name in your custom model configuration
 3. Or add multiple model entries and select between them in the chat
 
-## Model Recommendations by Task
+## Using Model Routes (Recommended)
 
-| Task | Recommended Model | Why |
-|------|-------------------|-----|
-| Quick fixes, linting | `gemini-3-flash` | Fast, cheap (1× quota) |
-| Feature implementation | `claude-4.5-sonnet` | Best balance of speed and quality |
-| Complex refactoring | `claude-4.5-opus` | Deep reasoning capability |
-| Debugging with context | `deepseek-r1` | Strong at tracing logic |
-| Code review | `qwen3-32b` | Good at explanations |
-| Routine boilerplate | `glm-4.7-flash` | Fast and free-tier friendly |
+Instead of switching model names manually, create a [Model Route](/en/coding-plan/model-routes) — a virtual alias that resolves to a chain of models with automatic failover:
 
-## Load-Based Quota Multipliers
+```bash
+# Set up once in the dashboard, then use everywhere:
+jelma claude local --model my-coder
+```
 
-Model multipliers (1× lightweight, 2× mid/flagship, up to 3× for flagship under load) determine how much quota each prompt costs. See [Quota & Limits](/en/coding-plan/quota-and-limits#load-based-model-multipliers) for the full breakdown.
+Benefits:
+- **No config changes needed** when you want to switch — just update the route in the dashboard
+- **Automatic failover** if the primary model is unavailable
+- **Consistent name** across all tools and machines
+
+## Quota Considerations
+
+- **Lightweight models** (1× multiplier) — best for routine tasks, preserves quota
+- **Mid-tier models** (2× multiplier) — good balance of quality and cost
+- **Frontier models** (up to 3× under load) — use selectively for complex tasks
+
+The exact multiplier depends on current gateway load. Check [Quota & Limits](/en/coding-plan/quota-and-limits) for details.
+
+<Tip>
+  Use lightweight models for quick fixes and code generation. Switch to premium models only for complex reasoning, architecture decisions, or multi-file refactoring. This strategy can 2–3× your effective quota.
+</Tip>

--- a/en/coding-plan/tool-integration.mdx
+++ b/en/coding-plan/tool-integration.mdx
@@ -1,0 +1,119 @@
+---
+title: "Tool Integration"
+description: "Supported coding tools and configuration guide for the Neosantara Coding Plan."
+---
+
+## Supported Tools
+
+The Neosantara Coding Plan works with any coding tool that supports the **OpenAI** or **Anthropic** API protocol. Below are officially tested tools:
+
+### Coding Agents
+
+<CardGroup cols={2}>
+  <Card title="Claude Code">
+    CLI-based coding agent by Anthropic. Uses Anthropic protocol.
+  </Card>
+  <Card title="Cline">
+    VS Code extension for AI-assisted coding. Uses OpenAI-compatible protocol.
+  </Card>
+  <Card title="Continue">
+    VS Code and JetBrains extension. Supports OpenAI-compatible.
+  </Card>
+  <Card title="OpenCode">
+    Terminal-based coding agent. Supports OpenAI-compatible.
+  </Card>
+  <Card title="Cursor">
+    AI-first code editor with custom model support.
+  </Card>
+  <Card title="Jelma">
+    Neosantara's built-in coding agent — no local setup needed.
+  </Card>
+</CardGroup>
+
+### General-purpose Agent Tools
+
+Any tool supporting the OpenAI Chat Completions or Anthropic Messages API can use the Coding Plan, including:
+- Roo Code, Kilo Code, Goose, Crush
+- Custom scripts using the OpenAI SDK or Anthropic SDK
+
+## Coding Endpoints
+
+| Protocol | Base URL | When to use |
+|----------|----------|-------------|
+| Anthropic Messages | `https://api.neosantara.xyz/coding/anthropic` | Claude Code, Goose, or any tool expecting Anthropic format |
+| OpenAI Chat Completions | `https://api.neosantara.xyz/coding/v1` | Cline, Continue, OpenCode, Cursor, and most other tools |
+
+<Warning>
+  **Important:** Coding keys (`nsk_code_*`) only work on these dedicated coding endpoints. Sending them to `/v1` or `/anthropic` (PAYG endpoints) returns `403`.
+</Warning>
+
+## Configuration Examples
+
+### Claude Code (Anthropic protocol)
+
+Edit `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "nsk_code_YOUR_KEY",
+    "ANTHROPIC_MODEL": "claude-4.5-sonnet",
+    "ANTHROPIC_SMALL_FAST_MODEL": "gemini-3-flash",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-4.5-sonnet",
+    "API_TIMEOUT_MS": "3600000"
+  }
+}
+```
+
+<Note>
+  Clear any existing `ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_BASE_URL` environment variables before configuring, to avoid conflicts.
+</Note>
+
+### Cline (OpenAI-compatible protocol)
+
+1. Open VS Code → Extensions → Cline settings
+2. Select **API Provider**: `OpenAI Compatible`
+3. Fill in:
+   - **Base URL**: `https://api.neosantara.xyz/coding/v1`
+   - **API Key**: `nsk_code_YOUR_KEY`
+   - **Model**: `claude-4.5-sonnet` (or any model from your tier)
+4. Uncheck **Support Images** (not supported on coding endpoints)
+5. Set **Context Window Size** based on model (e.g. `200000` for most, `1000000` for Gemini)
+
+### Continue / OpenCode
+
+In your tool's configuration:
+
+```
+Base URL: https://api.neosantara.xyz/coding/v1
+API Key:  nsk_code_YOUR_KEY
+Model:    claude-4.5-sonnet
+```
+
+### Cursor
+
+1. Settings → Models → Add Custom Model
+2. **OpenAI Base URL**: `https://api.neosantara.xyz/coding/v1`
+3. **API Key**: `nsk_code_YOUR_KEY`
+4. **Model name**: `claude-4.5-sonnet`
+
+### Jelma (Zero Configuration)
+
+Open [Jelma](https://app.neosantara.xyz/jelma) in your Neosantara dashboard. Select a coding agent and start — it uses your coding key and the coding endpoint automatically.
+
+## Verifying Your Setup
+
+After configuring, test with a simple prompt:
+
+```
+What is 2 + 2? Reply with just the number.
+```
+
+If you get a response, your Coding Plan is active and correctly configured. If you get an error:
+
+| Error | Solution |
+|-------|----------|
+| `403 coding_key_requires_coding_endpoint` | You're using the wrong base URL. Switch to `/coding/v1` or `/coding/anthropic`. |
+| `401 Unauthorized` | Check your API key — it should start with `nsk_code_`. |
+| `429 rate_limit_exceeded` | Your 5-hour or weekly quota is exhausted. Wait for the window to reset. |

--- a/en/coding-plan/usage-policy.mdx
+++ b/en/coding-plan/usage-policy.mdx
@@ -1,0 +1,40 @@
+---
+title: "Usage Policy"
+description: "Rules and fair-use guidelines for the Neosantara Coding Plan."
+---
+
+## Acceptable Use
+
+The Neosantara Coding Plan is intended exclusively for **AI-assisted software development** using supported coding tools. You agree to the following:
+
+1. **Supported tools only** — The plan may only be used with coding agents that communicate via the `/coding/v1` or `/coding/anthropic` endpoints (e.g. Claude Code, Cline, Continue, OpenCode, Jelma).
+2. **No automation abuse** — Automated scripts that artificially inflate prompt counts or circumvent rate limits are prohibited.
+3. **One user per key** — Coding keys are personal. Sharing keys across multiple users or organizations is not allowed.
+4. **No resale** — Reselling access or proxying the coding endpoints for third parties is prohibited.
+
+## Rate Limits
+
+| Window | Enforcement |
+|--------|-------------|
+| 5-hour rolling | Hard-stop when quota exhausted; auto-resets after 5 hours |
+| Weekly | Hard-stop when weekly quota exhausted; resets 7 days from subscription start |
+
+- No overage billing — requests are simply blocked until the window resets.
+- Flagship model multipliers rise to 3× (from 2× normal) when the model is under load, detected dynamically from upstream capacity.
+
+## Account Actions
+
+Neosantara reserves the right to:
+- Suspend or terminate coding plan access for policy violations.
+- Adjust quota limits with 7 days' notice if systemic abuse is detected.
+- Revoke keys that are shared publicly or used in unauthorized automation.
+
+## Refunds
+
+Coding Plan invoices are **non-refundable** once paid. If you experience a technical issue preventing usage, contact support@neosantara.xyz within 48 hours of purchase.
+
+## Data & Privacy
+
+- Coding Plan traffic is subject to the same [Privacy Policy](https://www.neosantara.xyz/privacy) as all Neosantara services.
+- We do not train models on your code or prompts.
+- Request logs are retained for billing verification and abuse detection only.

--- a/en/guides/jelma/best-practices.mdx
+++ b/en/guides/jelma/best-practices.mdx
@@ -1,0 +1,154 @@
+---
+title: "Best Practices"
+description: "Tips for getting the most out of Jelma — model selection, quota management, security, and workflow optimization."
+---
+
+## Model Selection
+
+### Use Model Routes for consistency
+
+Create a [Model Route](/en/coding-plan/model-routes) instead of hardcoding model names. This gives you:
+- **Automatic failover** — if your primary model is rate-limited, the next model in the chain takes over
+- **Easy switching** — change the chain in the dashboard without touching agent config
+- **Consistent naming** — use `my-coder` everywhere, resolve to different models per task
+
+```bash
+# Same command, model resolved by your route config
+jelma claude local --model my-coder
+jelma codex hetzner --model my-coder
+```
+
+### Match model to task complexity
+
+| Task | Recommended approach |
+|------|---------------------|
+| Simple fixes, formatting | Light model (DeepSeek Flash, GLM Flash) |
+| Multi-file refactoring | `garda-core` or premium model |
+| Complex reasoning | Premium model in first position of route chain |
+| Routine CI tasks | Cheapest model to save quota |
+
+### Save quota with lightweight models
+
+Coding Plan quota is consumed per prompt, but premium models may cost 2–3× during peak hours. Use light models for routine tasks:
+
+```bash
+jelma codex local --model deepseek-v4-flash  # Fast + cheap
+```
+
+## Security
+
+### Never commit credentials
+
+Jelma stores credentials in `~/.config/jelma/`. Never commit this directory. If you use `--config` files, exclude them from git:
+
+```bash
+echo "*.jelma-config.json" >> .gitignore
+```
+
+### Use environment variables for CI/CD
+
+```bash
+NEOSANTARA_API_KEY="$SECRET" \
+HCLOUD_TOKEN="$HCLOUD_SECRET" \
+jelma claude hetzner --headless --output json --prompt "Run tests"
+```
+
+### Clean up cloud resources
+
+Always delete VMs when done:
+```bash
+jelma status          # Check what's running
+jelma delete          # Interactive cleanup
+jelma status --prune  # Remove stale entries from history
+```
+
+## Workflow Tips
+
+### Use `--fast` for iterative development
+
+When spinning up agents repeatedly (testing configs, debugging), `--fast` saves minutes per launch:
+
+```bash
+jelma claude hetzner --fast --prompt "Fix the failing test"
+```
+
+### Headless mode for automation
+
+Integrate Jelma into scripts and CI pipelines:
+
+```bash
+result=$(jelma claude local \
+  --headless \
+  --output json \
+  --prompt "Analyze this codebase and list all TODOs")
+
+echo "$result" | jq '.output'
+```
+
+### Use `jelma fix` instead of re-provisioning
+
+If an agent's config got corrupted or credentials expired, don't delete and recreate:
+
+```bash
+jelma fix  # Re-injects credentials, re-runs agent setup
+```
+
+### Persistent preferences
+
+Set per-agent model defaults in `~/.config/spawn/preferences.json`:
+
+```json
+{
+  "models": {
+    "claude": "my-coder",
+    "codex": "garda-core",
+    "openclaw": "garda-core"
+  }
+}
+```
+
+Now `jelma claude local` always uses `my-coder` without `--model`.
+
+## Cloud-Specific Tips
+
+### Hetzner (cheapest)
+
+Best price/performance for development. Use `--zone` to pick a nearby datacenter:
+
+```bash
+jelma claude hetzner --zone fsn1  # Falkenstein, Germany
+jelma claude hetzner --zone sin1  # Singapore
+```
+
+### Local (fastest iteration)
+
+No provisioning delay. Use for rapid iteration:
+
+```bash
+jelma claude local --prompt "Fix this bug"
+jelma last  # Instant rerun with same config
+```
+
+### Recursive for complex tasks
+
+Let the agent spawn child agents for parallel subtasks:
+
+```bash
+jelma claude hetzner --beta recursive --prompt "Refactor the entire auth module"
+```
+
+The parent agent can use `jelma` inside the VM to spawn helpers.
+
+## Anti-Patterns
+
+<Warning>
+  Avoid these common mistakes:
+</Warning>
+
+| Don't | Do instead |
+|-------|-----------|
+| Leave VMs running overnight | `jelma delete` when done |
+| Hardcode model names in scripts | Use Model Routes or `preferences.json` |
+| Use premium models for everything | Match model to task complexity |
+| Skip `--dry-run` on expensive clouds | Always preview first on unfamiliar setups |
+| Store API keys in config files | Use environment variables |

--- a/en/guides/jelma/faq.mdx
+++ b/en/guides/jelma/faq.mdx
@@ -1,0 +1,140 @@
+---
+title: "FAQ"
+description: "Frequently asked questions about Jelma — installation, agents, billing, and troubleshooting."
+---
+
+## Installation
+
+<AccordionGroup>
+  <Accordion title="What are the system requirements?">
+    - **bun >= 1.2.0** (installer handles this)
+    - macOS, Linux, or Windows (WSL2 or PowerShell)
+    - Internet connection for agent downloads
+  </Accordion>
+
+  <Accordion title="How do I update Jelma?">
+    ```bash
+    jelma update
+    ```
+    Or reinstall:
+    ```bash
+    curl -fsSL https://cli.neosantara.xyz/install.sh | bash
+    ```
+  </Accordion>
+
+  <Accordion title="Where does Jelma store data?">
+    - **Config**: `~/.config/jelma/` (credentials, preferences)
+    - **History**: `~/.config/jelma/history.json`
+    - **Agent configs**: Written to standard locations per agent (`~/.claude/settings.json`, `~/.codex/config.toml`, etc.)
+  </Accordion>
+
+  <Accordion title="How do I uninstall?">
+    ```bash
+    jelma uninstall
+    ```
+    This removes the CLI binary and optionally clears `~/.config/jelma`.
+  </Accordion>
+</AccordionGroup>
+
+## Agents & Clouds
+
+<AccordionGroup>
+  <Accordion title="Which agent should I use?">
+    - **Claude Code** — Best overall agentic capability, strong at complex multi-file tasks
+    - **Codex CLI** — Fast, lightweight, great for quick fixes
+    - **OpenClaw** — Best for browser-heavy tasks (web scraping, testing)
+    - **OpenCode** — Open-source alternative, good for simple tasks
+    - **Hermes** — Research-oriented, strong reasoning
+    - **Pi** — Minimal and fast for small tasks
+  </Accordion>
+
+  <Accordion title="Can I use Jelma without a cloud?">
+    Yes. Choose `local` as the cloud target:
+    ```bash
+    jelma claude local
+    ```
+    This runs the agent directly on your machine with no cloud provisioning.
+  </Accordion>
+
+  <Accordion title="What cloud resources does Jelma create?">
+    A single VM (smallest available size by default). Jelma provisions, configures, and gives you SSH access. You're responsible for deleting it:
+    ```bash
+    jelma delete
+    ```
+  </Accordion>
+
+  <Accordion title="How do I use a custom model?">
+    Use `--model` with any model available on your plan:
+    ```bash
+    jelma claude local --model deepseek-v4-flash
+    ```
+    Coding Plan users can create [Model Routes](/en/coding-plan/model-routes) for virtual names with failover:
+    ```bash
+    jelma claude local --model my-coder
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Billing
+
+<AccordionGroup>
+  <Accordion title="How does billing work?">
+    Jelma supports two modes:
+    - **PAYG**: Regular API key, billed per token from your balance
+    - **Coding Plan**: Coding key (`nsk_code_*`), billed by prompt quota
+
+    Jelma detects your key type and routes to the correct endpoint automatically.
+  </Accordion>
+
+  <Accordion title="Does running Jelma cost anything beyond the model usage?">
+    The Jelma CLI itself is free. Model usage is billed through your Neosantara account. Cloud resources (VMs) are billed by the cloud provider at their standard rates.
+  </Accordion>
+
+  <Accordion title="What is garda-core?">
+    `garda-core` is Neosantara's experimental model with a 1M token context window. It's the default model Jelma uses. Coding Plan users can override it with `--model` or configure a [Model Route](/en/coding-plan/model-routes) that resolves `garda-core` to a custom failover chain.
+  </Accordion>
+</AccordionGroup>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Agent fails to install on the cloud VM">
+    Common causes:
+    1. **Network timeout** — Retry; package mirrors can be slow
+    2. **Missing credentials** — Ensure cloud credentials are set
+    3. **Region issues** — Try `--zone` with a different region
+
+    Use `--dry-run` to preview what Jelma will do before provisioning.
+  </Accordion>
+
+  <Accordion title="'Model not found' error">
+    Your model isn't available on your plan. Check available models:
+    ```bash
+    jelma models
+    ```
+    For Coding Plan users, ensure the model is in your tier's allowed list.
+  </Accordion>
+
+  <Accordion title="Claude Code exits immediately in headless mode">
+    You must provide `--prompt` when using `--headless`:
+    ```bash
+    # Wrong — Claude exits immediately
+    jelma claude gcp --headless --output json
+
+    # Right
+    jelma claude gcp --headless --output json --prompt "Fix linter errors"
+    ```
+  </Accordion>
+
+  <Accordion title="'coding_key_requires_coding_endpoint' error">
+    Your coding key (`nsk_code_*`) is hitting the PAYG endpoint. This shouldn't happen with Jelma (it auto-routes), but if using manual config ensure base URL is `/coding/v1` or `/coding/anthropic`.
+  </Accordion>
+
+  <Accordion title="How do I get help?">
+    ```bash
+    jelma help
+    jelma feedback "describe your issue"
+    ```
+    Or open an issue: [github.com/neosantara-xyz/jelma/issues](https://github.com/neosantara-xyz/jelma/issues)
+  </Accordion>
+</AccordionGroup>

--- a/en/guides/jelma/overview.mdx
+++ b/en/guides/jelma/overview.mdx
@@ -1,0 +1,85 @@
+---
+title: "Jelma Overview"
+description: "Launch any AI coding agent on any cloud with a single command. 9 agents, 8 clouds, zero config — all models powered by Neosantara."
+---
+
+## What is Jelma?
+
+**Jelma** is Neosantara's CLI tool that deploys AI coding agents anywhere — your machine, AWS, GCP, Hetzner, DigitalOcean, Daytona, E2B, or Sprite — with a single command. It handles credential injection, model configuration, and agent setup so you can start coding immediately.
+
+<Warning>
+  Jelma is **alpha** software. When running on a cloud, it provisions real resources on your account. Review outputs and use at your own risk.
+</Warning>
+
+## Why Jelma?
+
+| Without Jelma | With Jelma |
+|---------------|-----------|
+| Edit settings.json, env vars, config files manually | One command — everything injected |
+| Remember base URLs per protocol per billing mode | Automatically selected |
+| Paste API keys into each tool | Jelma uses your key for you |
+| Repeat for every machine/agent | `jelma <agent> <cloud>` anywhere |
+
+## Supported Agents
+
+| Agent | Description |
+|-------|-------------|
+| **Claude Code** | Anthropic's agentic coding CLI |
+| **Codex CLI** | OpenAI's coding agent for the terminal |
+| **OpenClaw** | Browser-powered coding TUI with Chrome integration |
+| **OpenCode** | Open-source terminal coding agent |
+| **Kilo Code** | Open-source AI coding agent CLI |
+| **Hermes** | Nous Research's agentic CLI |
+| **Junie** | JetBrains' coding agent |
+| **Cursor CLI** | Cursor's terminal-based coding agent |
+| **Pi** | Lightweight terminal coding agent |
+
+## Supported Clouds
+
+| Cloud | Auth method |
+|-------|-------------|
+| **Local Machine** | No cloud credentials needed |
+| **AWS Lightsail** | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
+| **Google Cloud** | `gcloud auth` |
+| **Hetzner** | `HCLOUD_TOKEN` |
+| **DigitalOcean** | `DIGITALOCEAN_ACCESS_TOKEN` |
+| **Daytona** | `DAYTONA_API_KEY` |
+| **E2B** | `E2B_API_KEY` |
+| **Sprite** | `sprite login` |
+
+## Billing Modes
+
+Jelma supports two billing modes:
+
+- **Pay-As-You-Go (PAYG)** — Uses your regular API key. Billed per token from your account balance. Endpoints: `/v1`, `/anthropic`.
+- **Coding Plan** — Uses a coding key (`nsk_code_*`). Billed by prompt quota (5-hour + weekly windows). Endpoints: `/coding/v1`, `/coding/anthropic`.
+
+Jelma automatically routes to the correct base URL based on your key type.
+
+## Model Routing
+
+By default, Jelma uses `garda-core` — Neosantara's experimental model with 1M context window. You can override with `--model`:
+
+```bash
+jelma claude local --model my-custom-route
+```
+
+Coding Plan users can define [Model Routes](/en/coding-plan/model-routes) in the dashboard to create virtual model names with automatic failover chains.
+
+## Quick Start
+
+```bash
+# Install
+curl -fsSL https://cli.neosantara.xyz/install.sh | bash
+
+# Launch interactively
+jelma
+
+# Launch directly
+jelma claude local
+jelma codex hetzner --model garda-core
+```
+
+<Card title="Next: Usage Guide" icon="arrow-right" href="/en/guides/jelma/usage">
+  Learn all commands, flags, and workflows.
+</Card>

--- a/en/guides/jelma/reference.mdx
+++ b/en/guides/jelma/reference.mdx
@@ -1,0 +1,129 @@
+---
+title: "Command Reference"
+description: "Complete reference of all Jelma CLI commands and flags."
+---
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `jelma` | Interactive agent + cloud picker |
+| `jelma <agent> <cloud>` | Launch agent on cloud directly |
+| `jelma <agent>` | Show available clouds for an agent |
+| `jelma <cloud>` | Show available agents for a cloud |
+| `jelma matrix` | Full agent × cloud compatibility matrix |
+| `jelma agents` | List all agents with descriptions |
+| `jelma clouds` | List all cloud providers |
+| `jelma models` | List available models for your key type |
+| `jelma list` | Browse previous instances |
+| `jelma tree` | Show recursive spawn tree |
+| `jelma last` | Rerun the most recent instance |
+| `jelma delete` | Interactively destroy a cloud server |
+| `jelma status` | Show live state of cloud servers |
+| `jelma fix` | Re-run agent setup on an existing VM |
+| `jelma link <ip>` | Register an existing VM by IP |
+| `jelma update` | Check for CLI updates |
+| `jelma uninstall` | Uninstall Jelma CLI |
+| `jelma feedback "msg"` | Send feedback |
+| `jelma help` | Show help |
+| `jelma version` | Show version |
+
+## Launch Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--prompt "text"` | `-p` | Non-interactive prompt |
+| `--prompt-file <path>` | `-f` | Prompt from file |
+| `--model <id>` | `-m` | Override model (e.g. `garda-core`, `my-route`) |
+| `--headless` | | Provision and exit (no interactive session) |
+| `--output json` | | JSON output on stdout (requires `--headless`) |
+| `--dry-run` | | Preview without provisioning |
+| `--zone <zone>` | | Set region/zone |
+| `--size <type>` | | Set instance size/type |
+| `--config <file>` | | Load options from JSON config |
+| `--steps <list>` | | Comma-separated setup steps |
+| `--custom` | | Show interactive size/region pickers |
+| `--fast` | | Enable all speed optimizations |
+| `--beta <feature>` | | Enable specific beta feature (repeatable) |
+| `--name <name>` | | Set custom instance name |
+
+## List / Delete / Status Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `-a <agent>` | | Filter by agent |
+| `-c <cloud>` | | Filter by cloud |
+| `--flat` | | Flat list (disable tree view) |
+| `--json` | | Output as JSON |
+| `--clear` | | Clear all history |
+| `--prune` | | Remove gone servers from history |
+| `--name <name>` | | Target by name (for delete) |
+| `--yes` | | Skip confirmation (for delete) |
+| `--cascade` | | Delete VM and all children |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `NEOSANTARA_API_KEY` | Neosantara API key (PAYG or coding) |
+| `JELMA_NO_COLOR` | Disable colored output |
+| `JELMA_NO_UNICODE` | Disable Unicode characters |
+| `JELMA_NO_UPDATE_CHECK` | Skip auto-update check |
+| `JELMA_PARENT_ID` | Parent instance ID (recursive mode) |
+| `JELMA_DEPTH` | Recursion depth (recursive mode) |
+
+## Setup Steps
+
+Control optional setup with `--steps`:
+
+```bash
+jelma openclaw gcp --steps github,browser
+jelma claude gcp --steps ""  # Skip all optional steps
+```
+
+| Step | Agents | Description |
+|------|--------|-------------|
+| `github` | All | GitHub CLI + git identity |
+| `reuse-api-key` | All | Reuse saved Neosantara key |
+| `browser` | OpenClaw | Chrome browser (~400 MB) |
+| `telegram` | OpenClaw | Telegram bot integration |
+| `whatsapp` | OpenClaw | WhatsApp linking (interactive QR) |
+
+## Agent Identifiers
+
+Use these exact names as `<agent>`:
+
+| ID | Agent |
+|----|-------|
+| `claude` | Claude Code |
+| `codex` | Codex CLI |
+| `openclaw` | OpenClaw |
+| `opencode` | OpenCode |
+| `kilocode` | Kilo Code |
+| `hermes` | Hermes |
+| `junie` | Junie |
+| `cursor` | Cursor CLI |
+| `pi` | Pi |
+
+## Cloud Identifiers
+
+Use these exact names as `<cloud>`:
+
+| ID | Cloud |
+|----|-------|
+| `local` | Your machine |
+| `aws` | AWS Lightsail |
+| `gcp` | Google Cloud Compute Engine |
+| `hetzner` | Hetzner Cloud |
+| `digitalocean` | DigitalOcean |
+| `daytona` | Daytona |
+| `e2b` | E2B |
+| `sprite` | Sprite |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | General error (provisioning failed, agent crashed) |
+| `130` | User interrupt (Ctrl+C) |

--- a/en/guides/jelma/usage.mdx
+++ b/en/guides/jelma/usage.mdx
@@ -1,0 +1,181 @@
+---
+title: "Usage"
+description: "Complete guide to using Jelma — install, launch agents, configure models, and manage cloud instances."
+---
+
+## Installation
+
+<Tabs>
+  <Tab title="macOS / Linux / WSL">
+    ```bash
+    curl -fsSL https://cli.neosantara.xyz/install.sh | bash
+    ```
+  </Tab>
+  <Tab title="Windows PowerShell">
+    ```powershell
+    irm https://cli.neosantara.xyz/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
+
+Requires **bun >= 1.2.0**. The installer handles bun if missing.
+
+## Basic Usage
+
+```bash
+# Interactive picker (agent → cloud → billing mode)
+jelma
+
+# Direct launch
+jelma <agent> <cloud>
+
+# Examples
+jelma claude local                         # Claude Code on your machine
+jelma codex hetzner                        # Codex CLI on Hetzner
+jelma openclaw sprite --prompt "Fix bugs"  # Non-interactive with prompt
+```
+
+## Credentials
+
+Jelma prompts for credentials on first run and saves them to `~/.config/jelma`:
+
+```bash
+# Neosantara key (required — powers the models)
+export NEOSANTARA_API_KEY="nsk_code_YOUR_KEY"
+
+# Cloud credentials (only for cloud deploys)
+export HCLOUD_TOKEN="..."              # Hetzner
+export DIGITALOCEAN_ACCESS_TOKEN="..." # DigitalOcean
+export AWS_ACCESS_KEY_ID="..."         # AWS
+```
+
+## Model Selection
+
+Default model is `garda-core` (1M context, experimental). Override with `--model`:
+
+```bash
+# Use a specific model
+jelma claude local --model deepseek-v4-flash
+
+# Use a custom Model Route (Coding Plan)
+jelma claude local --model my-coder
+
+# All model slots (main, background, fast) use the same name
+# Gateway resolves via your failover chain
+```
+
+Set a persistent per-agent model preference in `~/.config/spawn/preferences.json`:
+
+```json
+{
+  "models": {
+    "claude": "my-coder",
+    "codex": "garda-core"
+  }
+}
+```
+
+## Non-Interactive Mode
+
+Skip all prompts with flags + env vars:
+
+```bash
+jelma claude hetzner \
+  --prompt "Fix all linter errors" \
+  --headless \
+  --output json
+```
+
+Flags:
+- `--prompt "text"` / `-p "text"` — Send a prompt non-interactively
+- `--prompt-file <file>` / `-f <file>` — Prompt from file
+- `--headless` — Provision and exit (no SSH session)
+- `--output json` — Structured JSON output (requires `--headless`)
+- `--model <id>` / `-m <id>` — Override the model
+- `--dry-run` — Preview without provisioning
+
+## Instance Management
+
+```bash
+# List previous instances
+jelma list
+jelma list --json
+
+# Rerun last session
+jelma last
+
+# Delete a cloud server
+jelma delete
+jelma delete -c hetzner
+jelma delete --name jelma-abc --yes  # Headless delete
+
+# Check live status
+jelma status
+jelma status --prune  # Remove gone servers
+
+# Re-run agent setup on existing VM
+jelma fix
+jelma fix <jelma-id>
+```
+
+## Speed Optimizations
+
+```bash
+# Fast mode — parallel boot + tarballs + skip cloud-init
+jelma claude hetzner --fast
+
+# Individual beta features
+jelma claude gcp --beta tarball --beta parallel
+jelma openclaw local --beta sandbox  # Docker sandbox
+```
+
+| Feature | Description |
+|---------|-------------|
+| `tarball` | Pre-built tarball install (skip live npm) |
+| `images` | Pre-built cloud images/snapshots |
+| `parallel` | Server boot + setup prompts in parallel |
+| `recursive` | Install jelma on VM for nested spawns |
+| `sandbox` | Run local agent in Docker container |
+
+## Recursive Jelma
+
+Let spawned VMs create their own child VMs:
+
+```bash
+jelma claude hetzner --beta recursive
+```
+
+View the spawn tree:
+```bash
+jelma tree
+# jelma-abc  Claude Code / Hetzner  2m ago
+#   ├─ jelma-def  Codex CLI / Hetzner  1m ago
+#   └─ jelma-ghi  OpenClaw / Hetzner  30s ago
+```
+
+## Config File
+
+Load options from a JSON file:
+
+```json
+{
+  "model": "my-coder",
+  "steps": ["github", "browser"],
+  "name": "my-dev-box",
+  "setup": {
+    "github_token": "ghp_xxxx"
+  }
+}
+```
+
+```bash
+jelma codex gcp --config setup.json --headless --output json
+```
+
+## Without the CLI
+
+Every combination works as a standalone one-liner:
+
+```bash
+bash <(curl -fsSL https://cli.neosantara.xyz/sh/{cloud}/{agent}.sh)
+```

--- a/id/about/rate-limits.mdx
+++ b/id/about/rate-limits.mdx
@@ -23,11 +23,11 @@ Sistem menegakkan tiga jenis throughput limit:
 
 | Tier | RPM | ITPM | OTPM |
 | :--- | :--- | :--- | :--- |
-| Free | 3 | 15.000 | 2.000 |
-| Basic | 50 | 50.000 | 10.000 |
-| Standard | 1.000 | 450.000 | 90.000 |
-| Pro | 2.000 | 1.000.000 | 200.000 |
-| Enterprise | 4.000 | 4.000.000 | 800.000 |
+| Free | 15 | 30.000 | 8.000 |
+| Basic | 50 | 500.000 | 80.000 |
+| Standard | 1.000 | 2.000.000 | 320.000 |
+| Pro | 2.000 | 5.000.000 | 800.000 |
+| Enterprise | 4.000 | 10.000.000 | 1.600.000 |
 
 <Note>
 **Pembaruan Tier:** Tier throughput disesuaikan secara otomatis berdasarkan riwayat total deposit kamu. Lihat [Kredit Token & Harga](/id/about/billing-pricing#throughput-tiers-speed-limits) untuk detailnya.

--- a/id/coding-plan/best-practice.mdx
+++ b/id/coding-plan/best-practice.mdx
@@ -1,0 +1,103 @@
+---
+title: "Best Practice"
+description: "Kerangka praktis untuk bekerja dengan coding agent — menyusun tugas, perencanaan, aturan proyek, environment eksekusi, skill, otomatisasi, dan manajemen sesi."
+---
+
+Coding agent modern jauh lebih dari sekadar autocomplete: mereka membaca dan menavigasi codebase, mengedit file, menjalankan perintah, dan menyelesaikan tugas multi-langkah. Hasil yang bagus lebih ditentukan oleh cara Kamu menyusun pekerjaan di sekitar agent daripada trik prompt. Praktik di bawah ini adalah kerangka umum yang berlaku lintas tool.
+
+## 1. Perlakukan Coding Agent sebagai Kolaborator, Bukan Asisten Sekali Pakai
+
+Kesalahan umum adalah memperlakukan agent seperti kotak tanya-jawab: tanya, salin jawaban, selesai. Coding agent lebih tepat dipahami sebagai kolaborator yang bisa Kamu konfigurasi dan sempurnakan seiring waktu — lewat panduan proyek, koneksi tool, dan workflow yang bisa dipakai ulang. Nilainya datang dari *kombinasi* kapabilitas model dan workflow yang Kamu bangun di sekitarnya, bukan model saja.
+
+## 2. Susun Input Tugas: Konteks Mengalahkan Trik Prompt
+
+Di codebase nyata, deskripsi tugas yang efektif biasanya punya empat bagian:
+
+<CardGroup cols={2}>
+  <Card title="Goal">Apa yang dibuat atau diubah — perbaiki bug, tambah endpoint, refactor modul.</Card>
+  <Card title="Konteks">File terkait, pesan error, dokumentasi, atau contoh yang perlu dilihat agent.</Card>
+  <Card title="Constraint">Aturan engineering yang harus diikuti — standar kode, arsitektur, keamanan, batasan dependensi.</Card>
+  <Card title="Done when">Cara menilai selesai — test lulus, perilaku berubah, bug tidak muncul lagi.</Card>
+</CardGroup>
+
+Input terstruktur mengurangi tebak-tebakan dan membuat perubahan lebih mudah di-review.
+
+## 3. Rencanakan Sebelum Eksekusi untuk Tugas Kompleks
+
+Untuk tugas non-trivial, meminta agent langsung menulis kode mengundang error logika dan pekerjaan ulang. Minta agent **membuat rencana dulu, baru implementasi**: jelajahi codebase, identifikasi cakupan perubahan, dan konfirmasi pendekatannya sebelum mengedit. Banyak agent menyediakan mode "plan" khusus untuk ini.
+
+## 4. Simpan Aturan Berulang di File Konfigurasi Tingkat Proyek
+
+Kalau Kamu mengulang aturan yang sama di tiap prompt, workflow jadi tidak efisien dan instruksi mudah melenceng. Pindahkan panduan jangka panjang ke file konfigurasi tingkat proyek yang dimuat agent otomatis:
+
+```text
+- Struktur direktori proyek
+- Perintah build
+- Alur test
+- Standar kode
+- Proses submit PR
+```
+
+Patokannya: **instruksi sementara di prompt; aturan jangka panjang di file konfigurasi proyek.**
+
+## 5. Environment Eksekusi Menentukan Apa yang Bisa Dilakukan Agent
+
+Hasil yang tidak konsisten sering disalahkan ke model, padahal penyebabnya kerap environment eksekusi yang tidak lengkap. Agent diharapkan membaca/mengubah file, menjalankan perintah build dan test, memanggil tool eksternal, dan memakai version control. Saat environment salah konfigurasi, muncul kegagalan seperti:
+
+- tidak menemukan direktori proyek
+- tidak punya izin membaca atau mengubah file
+- perintah build atau test gagal
+- tool atau layanan eksternal tidak terjangkau
+
+Coding agent bergantung pada tiga jenis konteks:
+
+| Konteks | Cakupan |
+|---------|---------|
+| Task Context | prompt dan input untuk tugas saat ini |
+| Project Context | struktur repositori dan aturan engineering |
+| Environment Context | tool, izin, dan environment eksekusi |
+
+Environment Context menentukan **apa yang bisa dilakukan agent, dan seberapa jauh**.
+
+## 6. Libatkan Coding Agent di Seluruh Development Loop
+
+Sebuah perubahan kode jarang dinilai dari hasil generasi saja — ia harus lulus test, memenuhi standar, dan melewati review. Libatkan agent di seluruh loop:
+
+<Steps>
+  <Step title="Implementasi">Ubah atau tambah kode sesuai tugas.</Step>
+  <Step title="Tulis/update test">Tambah cakupan untuk perilaku baru atau bug yang diperbaiki.</Step>
+  <Step title="Jalankan test suite">Verifikasi perubahan berperilaku sesuai harapan.</Step>
+  <Step title="Jalankan pemeriksaan">Lint, format, dan type-check agar memenuhi standar engineering.</Step>
+  <Step title="Review diff">Periksa regresi dan perubahan tak disengaja.</Step>
+</Steps>
+
+Ini menggeser agent dari *generator* kode menjadi simpul eksekusi dalam development loop.
+
+## 7. Perluas Konteks Agent dengan MCP
+
+Banyak konteks yang dibutuhkan agent ada di luar repo — issue tracker, status CI, skema database, dokumentasi API. Menyalin-tempel manual tidak scalable. **Model Context Protocol (MCP)** menyediakan cara standar untuk menghubungkan tool eksternal sehingga agent bisa mengambil konteks real-time langsung. Ini memperluas batas konteks agent dari eksekutor tingkat repositori menjadi kolaborator yang beroperasi di dalam environment engineering-mu.
+
+## 8. Tangkap Workflow Berulang sebagai Skill
+
+Beberapa tugas muncul terus-menerus — review PR, analisis log, catatan rilis, debugging standar. Menjelaskannya dari nol tiap kali itu boros dan tidak konsisten. Kemas jadi **skill**: template workflow terstruktur yang bisa dipakai ulang dan diterapkan agent dengan cara yang sama setiap kali.
+
+> Kalau sebuah pola prompt atau alur tugas dipakai berulang, sebaiknya jadikan skill.
+
+## 9. Otomatiskan Workflow yang Stabil
+
+Setelah sebuah skill berjalan andal, otomatiskan. Banyak workflow bersifat repetitif atau berbasis waktu — ringkasan commit, investigasi CI yang gagal, memindai log, laporan mingguan. Skill mendefinisikan *bagaimana* workflow berjalan; otomatisasi mendefinisikan *kapan* ia berjalan dan bagaimana berlanjut seiring waktu. Ini mengubah agent dari tool interaktif menjadi asisten berkelanjutan.
+
+## 10. Kelola Sesi Agent secara Sengaja
+
+Sebuah sesi adalah working context yang mengumpulkan tujuan tugas, kode terkait, perubahan yang dibuat, dan reasoning perantara. Tanpa pengelolaan, tugas tak terkait menumpuk dan menurunkan kualitas reasoning. Kebiasaan praktis:
+
+- **Satu sesi per tugas** — jaga working context tetap fokus.
+- **Hindari sesi terlalu panjang** — ringkas atau kompres saat riwayat membengkak.
+- **Eksplorasi cabang pakai sesi sendiri** — jangan menumpuk investigasi baru ke sesi asli.
+- **Kompres riwayat berkala** — kurangi tekanan pada context window.
+
+Manajemen sesi adalah bentuk manajemen konteks: sesi yang jelas menjaga reasoning tetap koheren di tugas multi-langkah.
+
+## Kesimpulan
+
+Efektivitas coding agent datang dari workflow yang Kamu bangun di sekitarnya: konteks tugas yang jelas, perencanaan, aturan proyek yang tersimpan, environment eksekusi yang solid, tool yang terhubung, skill yang bisa dipakai ulang, otomatisasi, dan manajemen sesi yang sengaja. Bersama-sama, semua ini mengubah tool generasi kode menjadi kolaborator di seluruh siklus pengembangan.

--- a/id/coding-plan/faq.mdx
+++ b/id/coding-plan/faq.mdx
@@ -1,0 +1,133 @@
+---
+title: "FAQ Coding Plan"
+description: "Pertanyaan yang sering ditanyakan tentang Neosantara Coding Plan — kuota, billing, tool, dan troubleshooting."
+---
+
+## Detail Coding Plan
+
+<AccordionGroup>
+  <Accordion title="Berapa kuota yang disediakan paket ini?">
+    Tiap tier punya limit rolling 5 jam dan limit mingguan. Lihat tabel lengkap di [Kuota & Limit](/id/coding-plan/quota-and-limits#tier-paket). Tiap prompt biasanya memicu 15–20 panggilan model, jadi total bulanan efektif jauh melebihi harga API standar.
+  </Accordion>
+
+  <Accordion title="Kenapa kuota habis lebih cepat pakai model premium?">
+    Model premium (mis. Claude 4.5 Opus, `gemini-3-pro-preview`) memotong kuota hingga 3× saat model sedang under load. Saran kami:
+    - Pakai model ringan (Gemini 3 Flash, GLM-4.7 Flash) untuk tugas rutin.
+    - Simpan model premium untuk reasoning kompleks dan refactoring besar.
+  </Accordion>
+
+  <Accordion title="Apa yang dihitung sebagai 1 prompt?">
+    Satu giliran user di coding tool. Walaupun agent melakukan 15–20 panggilan model di balik layar (tool calls, reasoning steps), tetap dihitung 1 prompt.
+  </Accordion>
+
+  <Accordion title="Apa yang terjadi kalau kuota habis?">
+    Request di-**hard-stop** sampai jendela 5 jam atau mingguan berikutnya reset. Saldo tidak dipotong — tidak ada overage pay-as-you-go. Sistem tidak akan pernah memotong saldo PAYG-mu.
+  </Accordion>
+
+  <Accordion title="Tool apa saja yang didukung?">
+    Coding Plan bisa dipakai di tool apa pun yang mendukung format API OpenAI atau Anthropic:
+    - **Claude Code** (mode Anthropic)
+    - **Cline**, **Continue**, **OpenCode** (mode OpenAI)
+    - **Jelma** (coding agent bawaan Neosantara)
+
+    Semua tool yang didukung berbagi kuota yang sama di bawah langgananmu.
+  </Accordion>
+
+  <Accordion title="Model apa yang tersedia?">
+    Semua model di gateway Neosantara tersedia, sesuai daftar model yang diizinkan tier-mu. Termasuk Claude, Gemini, GPT, GLM, DeepSeek, dll.
+  </Accordion>
+</AccordionGroup>
+
+## Base URL & Konfigurasi
+
+<AccordionGroup>
+  <Accordion title="Kenapa muncul error '403 coding_key_requires_coding_endpoint'?">
+    Coding key (`nsk_code_*`) hanya bisa dipakai di base URL coding khusus:
+    - OpenAI-compatible: `https://api.neosantara.xyz/coding/v1`
+    - Anthropic-compatible: `https://api.neosantara.xyz/coding/anthropic`
+
+    Kalau kamu kirim coding key ke `/v1` atau `/anthropic` (endpoint PAYG), kamu akan dapat error ini. Update konfigurasi base URL di tool-mu.
+  </Accordion>
+
+  <Accordion title="Bisa pakai key PAYG biasa di /coding/v1?">
+    Key PAYG biasa yang dikirim ke `/coding/v1` diperlakukan sebagai request PAYG normal — tetap jalan, tapi memakai saldo PAYG dan **tidak** memakai kuota coding plan. Hanya coding key (`nsk_code_*`) yang menarik kuota coding plan, dan coding key hanya bisa dipakai di base URL coding.
+  </Accordion>
+
+  <Accordion title="Cara konfigurasi Claude Code?">
+    Edit `~/.claude/settings.json`:
+    ```json
+    {
+      "env": {
+        "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+        "ANTHROPIC_AUTH_TOKEN": "nsk_code_KEY_KAMU",
+        "ANTHROPIC_MODEL": "claude-4.5-sonnet"
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Cara konfigurasi Cline / Continue / OpenCode?">
+    Set di pengaturan tool:
+    ```
+    Base URL: https://api.neosantara.xyz/coding/v1
+    API Key:  nsk_code_KEY_KAMU
+    Model:    claude-4.5-sonnet
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Manajemen Langganan
+
+<AccordionGroup>
+  <Accordion title="Apakah Coding Plan diperpanjang otomatis?">
+    **Tidak.** Neosantara Coding Plan adalah invoice sekali bayar per periode. Kamu akan dapat email pengingat 3 hari sebelum berakhir dan bisa perpanjang dari [dashboard Coding Plan](https://app.neosantara.xyz/coding-plan).
+  </Accordion>
+
+  <Accordion title="Cara perpanjang?">
+    Buka [Coding Plan](https://app.neosantara.xyz/coding-plan) di dashboard, klik "Perpanjang Sekarang". Invoice Mayar baru akan dibuat.
+  </Accordion>
+
+  <Accordion title="Bisa refund?">
+    Langganan tidak bisa di-refund setelah invoice dibayar. Kami sarankan mulai dari tier Hemat untuk evaluasi sebelum upgrade.
+  </Accordion>
+
+  <Accordion title="Bisa upgrade di tengah periode?">
+    Bisa. Beli tier yang lebih tinggi — langsung aktif. Sisa nilai paket lama tidak di-pro-rate (anggap sebagai perpanjangan dini di tier lebih tinggi).
+  </Accordion>
+
+  <Accordion title="Apa yang terjadi kalau paket berakhir?">
+    Coding key-mu akan turun ke tier Free coding (kalau ada) atau jadi tidak aktif. Key dan saldo PAYG tidak terpengaruh.
+  </Accordion>
+</AccordionGroup>
+
+## Integrasi Jelma
+
+<AccordionGroup>
+  <Accordion title="Bisa pakai Coding Plan dengan Jelma?">
+    Bisa. Jelma adalah coding agent bawaan Neosantara. Buka [Jelma](https://app.neosantara.xyz/jelma) di dashboard, pilih coding agent, dan akan otomatis pakai coding key-mu — tanpa setup lokal.
+  </Accordion>
+
+  <Accordion title="Jelma pakai kuota yang sama?">
+    Ya. Jelma memakai kuota prompt yang sama seperti tool lain yang terhubung via coding key-mu.
+  </Accordion>
+</AccordionGroup>
+
+## Bantuan Teknis
+
+<AccordionGroup>
+  <Accordion title="Kenapa muncul 'Insufficient Balance' setelah beli Coding Plan?">
+    Biasanya karena kamu tidak mengarah ke endpoint coding yang benar. Pastikan:
+    1. Kamu pakai coding key (`nsk_code_*`), bukan key biasa.
+    2. Base URL-mu adalah `/coding/v1` atau `/coding/anthropic`, bukan `/v1`.
+    3. Model yang dipanggil ada di daftar yang diizinkan tier-mu.
+
+    Coding Plan tidak pernah memotong saldo PAYG. Kalau saldo terpotong, tool-mu routing ke endpoint yang salah.
+  </Accordion>
+
+  <Accordion title="Sudah langganan tapi key masih menunjukkan tier 'Free'">
+    Aktivasi plan terjadi setelah Mayar konfirmasi pembayaran. Kalau invoice menunjukkan SUCCESS tapi tier belum update:
+    1. Tunggu 1–2 menit untuk pemrosesan webhook.
+    2. Refresh halaman Coding Plan.
+    3. Kalau masih belum update, hubungi support@neosantara.xyz dengan invoice ID-mu.
+  </Accordion>
+</AccordionGroup>

--- a/id/coding-plan/faq.mdx
+++ b/id/coding-plan/faq.mdx
@@ -11,7 +11,7 @@ description: "Pertanyaan yang sering ditanyakan tentang Neosantara Coding Plan �
   </Accordion>
 
   <Accordion title="Kenapa kuota habis lebih cepat pakai model premium?">
-    Model premium (mis. Claude 4.5 Opus, `gemini-3-pro-preview`) memotong kuota hingga 3× saat model sedang under load. Saran kami:
+    Model premium (mis. Claude 4.5 Opus, `gemini-3.5-flash`) memotong kuota hingga 3× saat model sedang under load. Saran kami:
     - Pakai model ringan (Gemini 3 Flash, GLM-4.7 Flash) untuk tugas rutin.
     - Simpan model premium untuk reasoning kompleks dan refactoring besar.
   </Accordion>

--- a/id/coding-plan/faq.mdx
+++ b/id/coding-plan/faq.mdx
@@ -36,6 +36,18 @@ description: "Pertanyaan yang sering ditanyakan tentang Neosantara Coding Plan â
   <Accordion title="Model apa yang tersedia?">
     Semua model di gateway Neosantara tersedia, sesuai daftar model yang diizinkan tier-mu. Termasuk Claude, Gemini, GPT, GLM, DeepSeek, dll.
   </Accordion>
+
+  <Accordion title="Apakah ada batas concurrency?">
+    Ya. Coding Plan membatasi jumlah **request in-flight secara bersamaan** per user (bukan RPM). Ini mengontrol berapa banyak panggilan agent yang bisa berjalan sekaligus:
+
+    | Tier | Maks request bersamaan |
+    |------|------------------------|
+    | Coding Hemat | 4 |
+    | Coding Reguler | 10 |
+    | Coding Eksklusif | 20 |
+
+    Jika melebihi limit, request tambahan ditolak sampai request yang sedang berjalan selesai. Ini terpisah dari kuota prompt â€” concurrency membatasi berapa request yang berjalan *bersamaan*, sementara kuota membatasi *total* jumlah prompt per jendela.
+  </Accordion>
 </AccordionGroup>
 
 ## Base URL & Konfigurasi

--- a/id/coding-plan/faq.mdx
+++ b/id/coding-plan/faq.mdx
@@ -72,9 +72,14 @@ description: "Pertanyaan yang sering ditanyakan tentang Neosantara Coding Plan â
       "env": {
         "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
         "ANTHROPIC_AUTH_TOKEN": "nsk_code_KEY_KAMU",
-        "ANTHROPIC_MODEL": "claude-4.5-sonnet"
+        "ANTHROPIC_MODEL": "garda-core"
       }
     }
+    ```
+
+    Atau pakai Jelma (tanpa config manual):
+    ```bash
+    jelma claude local
     ```
   </Accordion>
 
@@ -83,7 +88,12 @@ description: "Pertanyaan yang sering ditanyakan tentang Neosantara Coding Plan â
     ```
     Base URL: https://api.neosantara.xyz/coding/v1
     API Key:  nsk_code_KEY_KAMU
-    Model:    claude-4.5-sonnet
+    Model:    garda-core
+    ```
+
+    Atau pakai Jelma:
+    ```bash
+    jelma opencode local
     ```
   </Accordion>
 </AccordionGroup>
@@ -121,6 +131,19 @@ description: "Pertanyaan yang sering ditanyakan tentang Neosantara Coding Plan â
 
   <Accordion title="Jelma pakai kuota yang sama?">
     Ya. Jelma memakai kuota prompt yang sama seperti tool lain yang terhubung via coding key-mu.
+  </Accordion>
+
+  <Accordion title="Cara pakai Model Route kustom di Jelma?">
+    Pakai flag `--model` dengan nama virtual model-mu:
+    ```bash
+    jelma claude local --model my-coder
+    jelma codex hetzner --model my-coder
+    ```
+    Jelma men-set nama virtual ke semua slot model, jadi gateway me-resolve setiap request (utama, background, fast) melalui failover chain-mu. Lihat [Model Routes](/id/coding-plan/model-routes) untuk setup.
+  </Accordion>
+
+  <Accordion title="Apa itu garda-core?">
+    `garda-core` adalah model default yang dipakai Jelma untuk user Coding Plan. Ini adalah nama model virtual yang di-resolve gateway Neosantara ke model terbaik yang tersedia di tier-mu. Kamu bisa override dengan `--model` atau dengan mengatur [Model Route](/id/coding-plan/model-routes) kustom di dashboard.
   </Accordion>
 </AccordionGroup>
 

--- a/id/coding-plan/jelma.mdx
+++ b/id/coding-plan/jelma.mdx
@@ -1,0 +1,118 @@
+---
+title: "Coding Helper (Jelma)"
+description: "Jalankan coding agent AI di Coding Plan tanpa edit satu pun file config. Jelma menyambungkan agent ke endpoint coding untukmu."
+---
+
+**Jelma** adalah coding helper bawaan Neosantara: meluncurkan coding agent AI apa pun — di mesinmu sendiri atau di cloud — cukup dengan satu perintah, semua model ditenagai Neosantara. Saat Kamu memilih mode billing **Coding Plan**, Jelma otomatis mengarahkan agent ke base URL coding (`/coding/v1`, `/coding/anthropic`) memakai coding key-mu, jadi Kamu **tidak perlu** repot mengedit `settings.json`, environment variable, atau base URL secara manual.
+
+<Note>
+  Jelma adalah cara tercepat coding dengan Coding Plan. Kalau Kamu lebih suka konfigurasi tool manual, lihat [Tool Integration](/id/coding-plan/tool-integration).
+</Note>
+
+<Warning>
+  Jelma masih **alpha**. Saat Kamu menjalankan agent di cloud, ia membuat resource cloud sungguhan di akunmu. Tinjau apa yang dijalankan dan gunakan dengan risiko sendiri.
+</Warning>
+
+## Kenapa pakai Jelma daripada setup manual?
+
+| Setup manual | Dengan Jelma |
+|--------------|-------------|
+| Edit `~/.claude/settings.json` / env var manual | Tidak ada yang perlu diedit — Jelma yang mengisi |
+| Harus ingat base URL coding yang benar per protokol | Dipilih otomatis dari mode billing-mu |
+| Tempel key `nsk_code_*` ke tiap tool | Jelma memakai coding key-mu untukmu |
+| Ulangi di tiap mesin/agent | Satu perintah, di mana saja |
+
+## Opsi A — Jelma via web (tanpa setup)
+
+Alur web **tidak butuh instalasi lokal**. Ia menjalankan agent untukmu dan memakai coding key-mu otomatis.
+
+<Steps>
+  <Step title="Buka Jelma">
+    Buka [Jelma](https://app.neosantara.xyz/jelma) di dashboard-mu.
+  </Step>
+  <Step title="Pilih mode billing Coding Plan">
+    Saat ditanya **"How do you want to bill this?"**, pilih **Coding Plan** (ditagih dari kuota prompt, bukan saldo PAYG). Jelma akan memakai key `nsk_code_*`-mu.
+
+    <Note>
+      Belum punya coding key? Buat dulu di halaman [Coding Plan](https://app.neosantara.xyz/coding-plan), lalu berlangganan tier.
+    </Note>
+  </Step>
+  <Step title="Pilih coding agent">
+    Pilih dari agent yang didukung (Claude Code, Codex, OpenCode, dan lainnya).
+  </Step>
+  <Step title="Pilih tempat menjalankannya">
+    Pilih **Mesinmu sendiri** atau provider cloud (AWS, GCP, Hetzner, DigitalOcean, Daytona, E2B, Sprite).
+  </Step>
+  <Step title="Luncurkan">
+    Jelma mengonfigurasi agent ke endpoint coding lalu menjalankannya. Mulai prompt — kuota ditarik dari Coding Plan-mu.
+  </Step>
+</Steps>
+
+## Opsi B — Jelma CLI
+
+Lebih suka terminal? Instal Jelma CLI dan biarkan ia menanyakan apa pun yang dibutuhkan.
+
+<Steps>
+  <Step title="Instal Jelma">
+    <Tabs>
+      <Tab title="macOS / Linux / WSL">
+        ```bash
+        curl -fsSL https://cli.neosantara.xyz/install.sh | bash
+        ```
+      </Tab>
+      <Tab title="Windows PowerShell">
+        ```powershell
+        irm https://cli.neosantara.xyz/install.ps1 | iex
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+  <Step title="Luncurkan agent">
+    Jalankan Jelma dan pilih mode billing **Coding Plan** saat ditanya. Jelma menanyakan apa pun yang Kamu lewati saat pertama kali jalan — termasuk coding key Neosantara-mu — dan menyimpannya di `~/.config/jelma`.
+
+    ```bash
+    jelma
+    ```
+  </Step>
+  <Step title="Isi kredensial sekali saja">
+    - **Coding key Neosantara** (`nsk_code_*`) — menenagai model lewat endpoint coding.
+    - **Kredensial cloud** — hanya jika Kamu memilih menjalankan di cloud (dilewati untuk "Mesinmu sendiri").
+
+    Jelma mengingat ini untuk lain kali, jadi peluncuran berikutnya cukup satu perintah.
+  </Step>
+</Steps>
+
+<Tip>
+  Di mode Coding Plan, Jelma memakai default `claude-4.5-sonnet` di endpoint coding. Kamu bisa ganti model kapan saja — lihat [Ganti Model](/id/coding-plan/switching-models).
+</Tip>
+
+## Coding agent yang didukung
+
+<CardGroup cols={2}>
+  <Card title="Claude Code">CLI coding agentic dari Anthropic</Card>
+  <Card title="Codex">Coding agent terminal dari OpenAI</Card>
+  <Card title="OpenClaw">TUI coding dengan integrasi Chrome</Card>
+  <Card title="OpenCode">Coding agent terminal open-source</Card>
+  <Card title="KiloCode">CLI coding agent AI open-source</Card>
+  <Card title="Cursor CLI">Coding agent terminal dari Cursor</Card>
+  <Card title="T3Code">GUI web untuk Claude Code dan Codex</Card>
+  <Card title="Hermes">CLI agentic dari Nous Research</Card>
+  <Card title="Junie">Coding agent dari JetBrains</Card>
+  <Card title="Pi">Coding agent terminal ringan</Card>
+</CardGroup>
+
+## Bisa jalan di mana
+
+`Mesinmu sendiri` · `AWS` · `Google Cloud` · `Hetzner` · `DigitalOcean` · `Daytona` · `E2B` · `Sprite`
+
+## Billing
+
+- Di mode **Coding Plan**, tiap agent yang diluncurkan Jelma ditagih dari **kuota prompt** (jendela 5 jam + mingguan) — bukan saldo PAYG.
+- Semua agent yang tersambung lewat Jelma berbagi kuota yang sama di bawah langgananmu.
+- Lebih suka billing per token? Pilih mode **Pay-As-You-Go**; Jelma akan memakai API key biasa di endpoint `/v1` dan `/anthropic`.
+
+## Pelajari lebih lanjut
+
+- [Jelma di GitHub](https://github.com/neosantara-xyz/jelma)
+- [Overview Coding Plan](/id/coding-plan/overview)
+- [Ganti Model](/id/coding-plan/switching-models)

--- a/id/coding-plan/jelma.mdx
+++ b/id/coding-plan/jelma.mdx
@@ -83,7 +83,12 @@ Lebih suka terminal? Instal Jelma CLI dan biarkan ia menanyakan apa pun yang dib
 </Steps>
 
 <Tip>
-  Di mode Coding Plan, Jelma memakai default `claude-4.5-sonnet` di endpoint coding. Kamu bisa ganti model kapan saja — lihat [Ganti Model](/id/coding-plan/switching-models).
+  Di mode Coding Plan, Jelma memakai default `garda-core` di endpoint coding. Override dengan `--model` untuk memakai [Model Route](/id/coding-plan/model-routes) atau model lain yang tersedia di plan-mu:
+
+  ```bash
+  jelma claude local --model josjis   # Pakai custom route "josjis"
+  jelma codex local --model deepseek-v4-flash
+  ```
 </Tip>
 
 ## Coding agent yang didukung

--- a/id/coding-plan/learning-path.mdx
+++ b/id/coding-plan/learning-path.mdx
@@ -1,0 +1,43 @@
+---
+title: "Learning Path"
+description: "Mulai di sini — rute tercepat menjelajahi Neosantara Coding Plan, dari langganan hingga mengoptimalkan kuota."
+---
+
+Baru di Coding Plan? Ikuti alur di bawah. Sudah tahu yang Kamu butuhkan? Lompat lewat kartu pintasan.
+
+## Mulai di Sini
+
+<Steps>
+  <Step title="Langganan & dapatkan coding key">
+    Pilih tier dan buat key `nsk_code_*`. Lihat [Overview](/id/coding-plan/overview) untuk cara kerja paket.
+  </Step>
+  <Step title="Hubungkan tool">
+    Sambungkan coding agent-mu — [Tool Integration](/id/coding-plan/tool-integration) untuk Claude Code, Cline, Continue, OpenCode, atau Cursor. Mau tanpa setup? Pakai [Jelma](/id/coding-plan/jelma).
+  </Step>
+  <Step title="Kirim prompt pertama">
+    Ikuti [Mulai Cepat](/id/coding-plan/quick-start) untuk verifikasi setup dan mulai coding.
+  </Step>
+  <Step title="Pahami kuotamu">
+    Pelajari cara kerja prompt, jendela, dan multiplier di [Kuota & Limit](/id/coding-plan/quota-and-limits).
+  </Step>
+  <Step title="Optimalkan">
+    Ganti model per tugas untuk hemat kuota — lihat [Ganti Model](/id/coding-plan/switching-models).
+  </Step>
+</Steps>
+
+## Pintasan
+
+<CardGroup cols={2}>
+  <Card title="Tanpa setup" href="/id/coding-plan/jelma">
+    Jalankan agent tanpa konfigurasi pakai Jelma.
+  </Card>
+  <Card title="Saya pakai Claude Code / Cline / Cursor" href="/id/coding-plan/tool-integration">
+    Konfigurasi manual untuk tool yang didukung.
+  </Card>
+  <Card title="Hemat kuota" href="/id/coding-plan/quota-and-limits">
+    Aturan kuota plus strategi ganti model.
+  </Card>
+  <Card title="Aturan & fair use" href="/id/coding-plan/usage-policy">
+    Apa yang diizinkan dan cara limit ditegakkan.
+  </Card>
+</CardGroup>

--- a/id/coding-plan/memory-mechanism.mdx
+++ b/id/coding-plan/memory-mechanism.mdx
@@ -1,0 +1,157 @@
+---
+title: "Mekanisme Memori"
+description: "Cara coding agent menyimpan konteks lintas tugas dan sesi — jenis memori, pola retrieve-assemble-update, memori berlapis, dan troubleshooting."
+---
+
+Memori memungkinkan coding agent menyimpan konteks lintas tugas dan sesi, mengurangi input berulang dan meningkatkan efisiensi. Dengan desain memori yang baik, agent terus memahami struktur proyek, konvensi engineering, dan preferensi Kamu, lalu memakainya ulang di pekerjaan berikutnya. Memori biasanya diatur berlapis seperti sesi, proyek, dan memori jangka panjang.
+
+## Kenapa Coding Agent Butuh Memori
+
+Model bahasa tidak menyimpan state antar panggilan dengan sendirinya. Mereka tidak bisa mengingat konteks proyek lintas sesi, mengakumulasi pengalaman, atau konsisten menyesuaikan preferensimu. Sistem agent mengatasinya dengan **memori eksternal**. Loop tipikalnya:
+
+```text
+Input user
+   ↓
+Pengambilan memori
+   ↓
+Perakitan konteks
+   ↓
+Reasoning model
+   ↓
+Aksi / tool call
+   ↓
+Pembaruan memori
+```
+
+Agent mengambil memori relevan sebelum tugas dan memperbaruinya setelah selesai — pola umum di sistem agent modern.
+
+## Arsitektur Memori
+
+Secara garis besar:
+
+```text
+Memori jangka pendek
+    └ konteks sesi
+
+Memori jangka panjang
+    ├ memori semantik
+    ├ memori episodik
+    └ memori prosedural
+```
+
+## Jenis Memori Inti
+
+<AccordionGroup>
+  <Accordion title="Memori sesi">
+    Konteks yang terikat tugas saat ini — riwayat percakapan, output tool terbaru, rencana saat ini, dan file dalam cakupan. Biasanya ada di context window model.
+  </Accordion>
+  <Accordion title="Memori proyek">
+    Informasi jangka panjang tentang seluruh codebase — arsitektur, standar kode, alur build, perintah umum. Biasanya ditulis ke file `.md` dan dimuat di awal sesi.
+  </Accordion>
+  <Accordion title="Memori semantik">
+    Pengetahuan faktual dan materi referensi — dokumentasi API, aturan bahasa, basis pengetahuan. Sering diimplementasikan dengan retrieval-augmented generation (RAG): embed query, cari di vector store, ambil dokumen, lalu reasoning.
+  </Accordion>
+  <Accordion title="Memori episodik">
+    Catatan pengalaman masa lalu — cara bug sebelumnya diperbaiki, akar penyebab kegagalan build, strategi debugging yang berhasil. Membantu agent belajar dari pekerjaan sebelumnya.
+  </Accordion>
+  <Accordion title="Memori prosedural">
+    Alur langkah demi langkah untuk menyelesaikan tugas — mis. rutinitas debugging: baca error log, cari file, tulis patch, jalankan test. Dipakai di prompt engineering, template workflow, dan policy.
+  </Accordion>
+</AccordionGroup>
+
+## Pola Memori Standar
+
+<Steps>
+  <Step title="Pengambilan memori">
+    Sebelum tugas, agent mengambil memori proyek, entri basis pengetahuan, dan pengalaman relevan, lalu menyuntikkannya ke working context.
+  </Step>
+  <Step title="Perakitan konteks">
+    Memori yang diambil dirakit jadi konteks lengkap dan diteruskan ke model.
+  </Step>
+  <Step title="Pembaruan memori">
+    Setelah tugas, agent memutuskan apakah menulis memori baru — aturan yang baru ditemukan, pengalaman debugging, atau preferensi.
+  </Step>
+</Steps>
+
+## Memakai Memori dengan Benar
+
+Memori yang efektif itu **berlapis, terkontrol, bisa diambil, dan bisa diperbarui**. Alih-alih berharap model "mengingat semuanya", buat pola jelas tentang apa yang disimpan di mana.
+
+### Pisahkan memori instruksi dari memori pembelajaran
+
+- **Memori instruksi** ditulis manusia untuk memberi tahu agent cara bekerja — standar kode, konvensi direktori, perintah build/test, penamaan, aturan commit, aturan keamanan.
+- **Memori pembelajaran** terakumulasi seiring waktu dari koreksi, preferensi, percobaan yang gagal, dan kebiasaanmu.
+
+Mencampurnya membuat perilaku melenceng. Tulis **aturan dan batasan** ke memori instruksi (stabil, dapat diprediksi), dan **pengalaman serta preferensi** ke memori pembelajaran (membaik seiring waktu). Memisahkannya mencegah catatan pengalaman mencemari aturan inti.
+
+### Manajemen memori berlapis
+
+| Lapisan | Cakupan | Contoh |
+|---------|---------|--------|
+| Organisasi | semua developer/proyek | keamanan & kepatuhan, standar review, direktori terbatas, batasan dependensi/lisensi |
+| Proyek | dibagi tim, version-controlled | arsitektur, konvensi direktori, perintah build/test, penamaan, workflow |
+| User | personal, lintas proyek | gaya favorit, urutan debugging, format output, shortcut |
+| Lokal | mesin ini, tidak di-commit | akun test, port lokal, endpoint mock, catatan spesifik mesin |
+| Role / agent | satu agent khusus | perintah test untuk testing agent, batas modul untuk refactoring agent |
+
+Memori organisasi adalah lapisan tata kelola prioritas tertinggi dan tidak boleh dilewati sembarangan. Memori proyek adalah lapisan bersama yang paling penting.
+
+### Muat file `.md` berdasarkan path
+
+Untuk repositori besar, pecah instruksi ke beberapa file Markdown fokus per topik (mis. `testing.md`, `api-design.md`, `security.md`) dan muat berdasarkan path hanya saat relevan. Tiga prinsip:
+
+- Batasi file memori utama untuk konteks bersama global.
+- Buat aturan khusus modular — satu topik per file.
+- Kalau aturan bisa dimuat lewat path, jangan muat global; bawa hanya saat dibutuhkan.
+
+Struktur memori bisa terlihat seperti ini:
+
+```text
+agent-memory/
+├── project.md            # Ringkasan proyek
+├── rules/
+│   ├── code-style.md     # Gaya kode
+│   ├── testing.md        # Konvensi testing
+│   ├── api-design.md     # Panduan desain API
+│   ├── security.md       # Persyaratan keamanan
+│   └── frontend/
+│       └── react.md      # Aturan khusus frontend
+└── local/
+    └── developer.local.md
+```
+
+### Tulis aturan memori sebagai instruksi konkret
+
+Pakai aturan spesifik dan bisa diverifikasi, bukan prinsip abstrak. Lebih baik:
+
+- Pakai indentasi 2 spasi di semua file TypeScript baru.
+- Jalankan `pnpm test` setelah mengubah logika bisnis.
+- Letakkan semua API handler di `src/api/handlers/`.
+- Jaga komponen halaman di bawah 300 baris; pecah yang lebih besar jadi hook atau komponen anak.
+
+Ketimbang pernyataan kabur seperti "jaga kode tetap bersih" atau "tulis test yang baik". Jaga file memori utama ringkas (idealnya di bawah ~200 baris) dan pakai heading serta list Markdown.
+
+### Pisahkan aturan bersama dari preferensi pribadi
+
+Definisikan cakupan dan pemilik tiap aturan: proyek (tim, version-controlled), organisasi (IT/DevOps pusat), user (individu), lokal (satu mesin), role (agent khusus). Pertanyaan pemandunya: **siapa yang memiliki, siapa yang berbagi, dan berlaku untuk siapa.** Batasan yang jelas mencegah aturan membengkak dan duplikasi.
+
+### Pakai ulang memori lewat import dan paket aturan
+
+Banyak aturan adalah konvensi bersama lintas repositori. Menulis ulang di tiap repo mengundang inkonsistensi. Bila tooling mendukung, import file aturan bersama atau tautkan direktori aturan bersama, dan bangun paket aturan yang bisa dipakai ulang (mis. aturan keamanan, aturan frontend, aturan testing). Tiap proyek mereferensikan hanya modul yang dibutuhkan, sehingga aturan dikelola terpusat dan diterapkan konsisten.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Agent tidak mengikuti file memori .md saya">
+    File `.md` adalah instruksi kontekstual, bukan konfigurasi yang dipaksakan. Agent berusaha mengikutinya tapi tidak bisa menjamin kepatuhan saat aturan kabur atau bertabrakan. Pastikan file termuat, berada di path/scope yang diizinkan, dan tidak ada dua file yang memberi instruksi bertentangan untuk perilaku yang sama.
+  </Accordion>
+  <Accordion title="Saya tidak tahu apa yang disimpan auto-memory">
+    Banyak agent menyimpan auto-memory latar sebagai file Markdown. Pakai perintah memori tool untuk melihat direktori memori, lalu baca, edit, atau hapus file itu langsung.
+  </Accordion>
+  <Accordion title="File memori saya terlalu besar">
+    File berukuran besar memakan context window, menurunkan kepatuhan, dan menambah konflik. Pecah konten detail ke beberapa file Markdown dan referensikan atau import, atau pindahkan aturan ke direktori `rules/` khusus.
+  </Accordion>
+  <Accordion title="Instruksi hilang setelah kompresi konteks">
+    Percakapan panjang dikompres. File memori biasanya dimuat ulang dari disk setelahnya, jadi hanya konten yang tertulis di file yang bertahan. Kalau aturan hilang setelah kompresi, aturan itu hanya ada di percakapan. Tulis instruksi jangka panjang ke file `.md`, jangan mengandalkan percakapan.
+  </Accordion>
+</AccordionGroup>

--- a/id/coding-plan/model-routes.mdx
+++ b/id/coding-plan/model-routes.mdx
@@ -44,6 +44,14 @@ Buka [Coding Plan](https://app.neosantara.xyz/coding-plan) di dashboard. Bagian 
 
 Setelah dibuat, pakai nama virtual di mana pun Kamu biasa menentukan model:
 
+**Jelma CLI** (direkomendasikan — tanpa config):
+```bash
+jelma claude local --model my-coder
+jelma codex hetzner --model my-coder
+```
+
+Jelma meneruskan nama virtual ke flag model agent dan file settings, jadi semua slot model (utama, background, fast) melewati chain Kamu.
+
 **Claude Code** (`~/.claude/settings.json`):
 ```json json
 {

--- a/id/coding-plan/model-routes.mdx
+++ b/id/coding-plan/model-routes.mdx
@@ -31,34 +31,7 @@ my-coder → claude-4.5-sonnet (utama)
 
 ## Mengelola Routes
 
-### Via Dashboard
-
 Buka [Coding Plan](https://app.neosantara.xyz/coding-plan) di dashboard. Bagian **Model Routes** memungkinkan Kamu membuat, mengedit, dan menghapus route secara visual.
-
-### Via API
-
-**List routes:**
-```bash bash
-curl https://api.neosantara.xyz/v1/coding/model-routes \
-  -H "Authorization: Bearer nsk_code_KEY_KAMU"
-```
-
-**Buat/update route:**
-```bash bash
-curl -X POST https://api.neosantara.xyz/v1/coding/model-routes \
-  -H "Authorization: Bearer nsk_code_KEY_KAMU" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "virtual_name": "my-coder",
-    "model_chain": ["claude-4.5-sonnet", "gemini-3-flash"]
-  }'
-```
-
-**Hapus route:**
-```bash bash
-curl -X DELETE https://api.neosantara.xyz/v1/coding/model-routes/ROUTE_ID \
-  -H "Authorization: Bearer nsk_code_KEY_KAMU"
-```
 
 ## Aturan
 

--- a/id/coding-plan/model-routes.mdx
+++ b/id/coding-plan/model-routes.mdx
@@ -1,0 +1,93 @@
+---
+title: "Model Routes"
+description: "Buat alias model virtual dengan fallback chain — petakan nama kustom ke urutan model yang otomatis failover."
+---
+
+**Model Routes** memungkinkan Kamu mendefinisikan alias model kustom yang mengarah ke rantai model asli. Saat model utama tidak tersedia (rate-limited atau error), request otomatis dialihkan ke model berikutnya dalam rantai — tanpa perlu logika retry di sisi klien.
+
+<Note>
+  Model Routes memerlukan **Coding Plan aktif** (langganan berbayar atau trial). Hanya berlaku pada request yang dibuat dengan coding key (`nsk_code_*`) melalui coding endpoint.
+</Note>
+
+## Cara Kerja
+
+1. Kamu membuat nama virtual (mis. `my-coder`) dan menetapkan model chain (mis. `["claude-4.5-sonnet", "gemini-3-flash"]`).
+2. Saat Kamu mengirim request dengan `model: "my-coder"` di coding endpoint, sistem mencoba model pertama dalam rantai.
+3. Jika model pertama gagal (capacity error), otomatis mencoba model berikutnya, dan seterusnya.
+
+```text
+my-coder → claude-4.5-sonnet (utama)
+              ↓ (capacity error)
+           gemini-3-flash (fallback)
+```
+
+## Limit
+
+| Tier | Maks model per chain | Maks route per user |
+|------|---------------------|---------------------|
+| Coding Hemat | 3 | 10 |
+| Coding Reguler | 5 | 10 |
+| Coding Eksklusif | 8 | 10 |
+
+## Mengelola Routes
+
+### Via Dashboard
+
+Buka [Coding Plan](https://app.neosantara.xyz/coding-plan) di dashboard. Bagian **Model Routes** memungkinkan Kamu membuat, mengedit, dan menghapus route secara visual.
+
+### Via API
+
+**List routes:**
+```bash bash
+curl https://api.neosantara.xyz/v1/coding/model-routes \
+  -H "Authorization: Bearer nsk_code_KEY_KAMU"
+```
+
+**Buat/update route:**
+```bash bash
+curl -X POST https://api.neosantara.xyz/v1/coding/model-routes \
+  -H "Authorization: Bearer nsk_code_KEY_KAMU" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "virtual_name": "my-coder",
+    "model_chain": ["claude-4.5-sonnet", "gemini-3-flash"]
+  }'
+```
+
+**Hapus route:**
+```bash bash
+curl -X DELETE https://api.neosantara.xyz/v1/coding/model-routes/ROUTE_ID \
+  -H "Authorization: Bearer nsk_code_KEY_KAMU"
+```
+
+## Aturan
+
+- Nama virtual tidak boleh bertabrakan dengan ID model asli (mis. Kamu tidak bisa memberi nama route `claude-4.5-sonnet`).
+- Nama virtual case-insensitive dan unik per user.
+- Setiap model dalam chain harus tersedia di tier coding plan Kamu.
+- Panjang nama virtual maks: 100 karakter.
+
+## Memakai Route di Tool
+
+Setelah dibuat, pakai nama virtual di mana pun Kamu biasa menentukan model:
+
+**Claude Code** (`~/.claude/settings.json`):
+```json json
+{
+  "env": {
+    "ANTHROPIC_MODEL": "my-coder"
+  }
+}
+```
+
+**Cline / Continue / OpenCode:**
+```text
+Model: my-coder
+```
+
+Coding endpoint menerjemahkan `my-coder` → chain Kamu → model pertama yang tersedia, secara transparan.
+
+## Terkait
+
+- [Ganti Model](/id/coding-plan/switching-models) — pilih model per tugas.
+- [Kuota & Limit](/id/coding-plan/quota-and-limits) — cara multiplier bekerja per model.

--- a/id/coding-plan/overview.mdx
+++ b/id/coding-plan/overview.mdx
@@ -1,0 +1,90 @@
+---
+title: "Overview"
+description: "Langganan flat-fee khusus AI coding agent. Kuota berbasis prompt, tanpa overage, tanpa perpanjangan otomatis."
+---
+
+**Neosantara Coding Plan** adalah paket langganan yang dirancang khusus untuk workflow AI coding. Bisa dipakai di tool seperti **Neo Code**, **Claude Code**, **Cline**, dan **OpenCode**.
+
+<Note>
+  Coding Plan menggunakan **base URL khusus** (`/coding/v1` dan `/coding/anthropic`). Coding key (`nsk_code_*`) **tidak bisa** dipakai di endpoint PAYG biasa (`/v1`, `/anthropic`) — ditolak dengan `403`. Key PAYG biasa yang dikirim ke base URL coding cuma diperlakukan sebagai request PAYG normal dan **tidak** memakai kuota coding plan.
+</Note>
+
+## Cara Kerja
+
+| Konsep | Detail |
+|--------|--------|
+| **1 prompt** | 1 giliran user di coding tool — bisa memicu ~15–20 panggilan model di balik layar (agent loop) |
+| **Jendela kuota** | Rolling 5 jam + mingguan. Reset otomatis. |
+| **Overage** | Tidak ada. Request di-hard-stop sampai window reset. |
+| **Auto-renew** | Tidak. Kamu dapat pengingat 3 hari sebelum berakhir dan bisa perpanjang dari dashboard. |
+
+## Base URL Khusus
+
+Coding key (`nsk_code_*`) hanya bisa dipakai di path coding:
+
+| Protokol | Base URL |
+|----------|----------|
+| OpenAI-compatible | `https://api.neosantara.xyz/coding/v1` |
+| Anthropic-compatible | `https://api.neosantara.xyz/coding/anthropic` |
+
+<Warning>
+  Coding key yang dikirim ke endpoint biasa (`/v1` atau `/anthropic`) akan menerima error `403 coding_key_requires_coding_endpoint`.
+</Warning>
+
+## Mulai Cepat
+
+<Steps>
+  <Step title="Buat Coding Key">
+    Buka [Coding Plan](https://app.neosantara.xyz/coding-plan) atau [API Keys](https://app.neosantara.xyz/api-keys), buat key dengan prefix `[CODE]`.
+  </Step>
+  <Step title="Langganan Paket">
+    Pilih tier (Hemat / Reguler / Eksklusif) lalu selesaikan pembayaran invoice Mayar.
+  </Step>
+  <Step title="Konfigurasi Tool">
+    Arahkan coding agent ke base URL coding dengan coding key-mu.
+
+    **Claude Code** (`~/.claude/settings.json`):
+    ```json
+    {
+      "env": {
+        "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+        "ANTHROPIC_AUTH_TOKEN": "nsk_code_KEY_KAMU",
+        "ANTHROPIC_MODEL": "claude-4.5-sonnet"
+      }
+    }
+    ```
+
+    **Cline / Continue / OpenCode** (mode OpenAI):
+    ```
+    Base URL: https://api.neosantara.xyz/coding/v1
+    API Key:  nsk_code_KEY_KAMU
+    Model:    claude-4.5-sonnet
+    ```
+  </Step>
+  <Step title="Atau Pakai Jelma">
+    Buka [Jelma](https://app.neosantara.xyz/jelma) di dashboard untuk langsung spawn coding agent Neosantara — tanpa setup lokal.
+  </Step>
+</Steps>
+
+## Kuota & Limit
+
+Kuota berbasis prompt: **1 prompt = 1 giliran user**, berapa pun panggilan model yang dilakukan agent secara internal. Tidak ada overage — saat kuota sebuah jendela habis, request diblokir sampai reset.
+
+Lihat [Kuota & Limit](/id/coding-plan/quota-and-limits) untuk tabel harga tier lengkap, jendela 5 jam/mingguan, dan multiplier model berbasis beban.
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Apakah Coding Plan diperpanjang otomatis?">
+    Tidak. Ini invoice sekali bayar per periode. Kamu dapat email pengingat 3 hari sebelum berakhir.
+  </Accordion>
+  <Accordion title="Apa yang terjadi kalau kuota habis?">
+    Request diblokir (hard-stop) sampai jendela 5 jam atau mingguan berikutnya reset. Saldo tidak dipotong.
+  </Accordion>
+  <Accordion title="Bisa pakai coding key di endpoint /v1 biasa?">
+    Tidak. Coding key hanya bekerja di `/coding/v1` dan `/coding/anthropic`. Key PAYG biasa bekerja di `/v1` dan `/anthropic`.
+  </Accordion>
+  <Accordion title="Model apa saja yang tersedia?">
+    Semua model yang ada di gateway Neosantara, sesuai daftar model yang diizinkan tier-mu.
+  </Accordion>
+</AccordionGroup>

--- a/id/coding-plan/quick-start.mdx
+++ b/id/coding-plan/quick-start.mdx
@@ -1,0 +1,142 @@
+---
+title: "Mulai Cepat"
+description: "Mulai pakai Neosantara Coding Plan dalam hitungan menit — dari langganan sampai coding dengan AI agent."
+---
+
+Panduan ini membantu kamu mulai pakai [Neosantara Coding Plan](/id/coding-plan/overview) dalam hitungan menit.
+
+## Mulai
+
+<Steps>
+  <Step title="Daftar atau Login">
+    Buka [Dashboard Neosantara](https://app.neosantara.xyz) dan daftar atau login.
+  </Step>
+
+  <Step title="Langganan Coding Plan">
+    Buka halaman [Coding Plan](https://app.neosantara.xyz/coding-plan) dan pilih tier:
+
+    | Tier | Limit 5 Jam | Limit Mingguan | Harga |
+    |------|-------------|----------------|-------|
+    | Coding Hemat | ~80 prompt | ~400 prompt | Rp 149.000/bln |
+    | Coding Reguler | ~400 prompt | ~2.000 prompt | Rp 499.000/bln |
+    | Coding Eksklusif | ~1.600 prompt | ~8.000 prompt | Rp 1.290.000/bln |
+
+    Selesaikan pembayaran invoice Mayar. Plan aktif dalam 1–2 menit.
+  </Step>
+
+  <Step title="Buat Coding Key">
+    Setelah langganan, buat coding key dari halaman [Coding Plan](https://app.neosantara.xyz/coding-plan) atau [API Keys](https://app.neosantara.xyz/api-keys). Key-mu akan berbentuk `nsk_code_...`.
+
+    <Warning>
+      Simpan coding key dengan aman. Tidak bisa ditampilkan lagi setelah dibuat.
+    </Warning>
+  </Step>
+
+  <Step title="Hubungkan Coding Tool">
+    Neosantara Coding Plan bisa dipakai di tool apa pun yang mendukung format API OpenAI atau Anthropic:
+
+    <CardGroup cols={3}>
+      <Card title="Claude Code" href="#claude-code">CLI agent dari Anthropic</Card>
+      <Card title="Cline" href="#cline">Ekstensi VS Code</Card>
+      <Card title="Continue" href="#continue--opencode">VS Code / JetBrains</Card>
+      <Card title="OpenCode" href="#continue--opencode">Terminal agent</Card>
+      <Card title="Cursor" href="#cursor">Editor AI-first</Card>
+      <Card title="Jelma" href="#jelma">Bawaan Neosantara (tanpa setup)</Card>
+    </CardGroup>
+  </Step>
+
+  <Step title="Panduan Endpoint">
+    Neosantara Coding Plan mendukung protokol Anthropic dan OpenAI. Gunakan **base URL coding** yang benar:
+
+    | Protokol | Base URL |
+    |----------|----------|
+    | Anthropic Messages | `https://api.neosantara.xyz/coding/anthropic` |
+    | OpenAI Chat Completions | `https://api.neosantara.xyz/coding/v1` |
+
+    <Warning>
+      Menggunakan endpoint yang salah (mis. `/v1` bukan `/coding/v1`) akan menghasilkan error `403 coding_key_requires_coding_endpoint`.
+    </Warning>
+  </Step>
+
+  <Step title="Mulai Coding">
+    Setelah dikonfigurasi, mulai coding dengan AI:
+
+    <Tabs>
+      <Tab title="Pemrograman Natural Language">
+        ```
+        # Deskripsikan yang kamu mau
+        Buat komponen React dengan form login yang validasi email dan password
+        ```
+      </Tab>
+      <Tab title="Debugging">
+        ```
+        # Deskripsikan masalahnya
+        API request saya return 404 error. Cek konfigurasi routing.
+        ```
+      </Tab>
+      <Tab title="Optimasi Kode">
+        ```
+        # Minta perbaikan
+        Fungsi ini O(n²). Optimasi jadi O(n log n).
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+</Steps>
+
+## Konfigurasi Tool
+
+### Claude Code
+
+Edit `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "nsk_code_KEY_KAMU",
+    "ANTHROPIC_MODEL": "claude-4.5-sonnet",
+    "ANTHROPIC_SMALL_FAST_MODEL": "gemini-3-flash",
+    "API_TIMEOUT_MS": "3600000"
+  }
+}
+```
+
+Verifikasi dengan `/status` — pastikan model dan base URL benar.
+
+### Cline
+
+Di VS Code, buka pengaturan Cline:
+1. **API Provider**: Pilih `OpenAI Compatible`
+2. **Base URL**: `https://api.neosantara.xyz/coding/v1`
+3. **API Key**: `nsk_code_KEY_KAMU`
+4. **Model**: Masukkan `claude-4.5-sonnet` (atau model lain)
+
+### Continue / OpenCode
+
+```
+Base URL: https://api.neosantara.xyz/coding/v1
+API Key:  nsk_code_KEY_KAMU
+Model:    claude-4.5-sonnet
+```
+
+### Cursor
+
+1. Settings → Models → Add Model
+2. **Base URL**: `https://api.neosantara.xyz/coding/v1`
+3. **API Key**: `nsk_code_KEY_KAMU`
+4. **Model**: `claude-4.5-sonnet`
+
+### Jelma
+
+Tanpa konfigurasi. Buka [Jelma](https://app.neosantara.xyz/jelma) di dashboard, pilih coding agent, dan mulai. Jelma otomatis pakai coding key-mu.
+
+## Tips Hemat Kuota
+
+<Tip>
+  **Pakai model ringan untuk tugas rutin.** `gemini-3-flash` dan `glm-4.7-flash` makan 1× kuota; model flagship lebih mahal (hingga 3× saat under load). Lihat [Kuota & Limit](/id/coding-plan/quota-and-limits) untuk tabel multiplier lengkap.
+</Tip>
+
+- **1 prompt = 1 giliran user** — berapa pun panggilan model yang dilakukan agent secara internal (~15–20 panggilan per giliran biasanya).
+- **Kuota reset otomatis** pada jendela rolling 5 jam dan mingguan.
+- **Tanpa overage** — saat kuota habis, request diblokir sampai window berikutnya. Saldo tidak dipotong.

--- a/id/coding-plan/quota-and-limits.mdx
+++ b/id/coding-plan/quota-and-limits.mdx
@@ -1,0 +1,65 @@
+---
+title: "Kuota & Limit"
+description: "Cara kerja kuota Neosantara Coding Plan — prompt, jendela 5 jam dan mingguan, limit tier, dan multiplier model berbasis beban."
+---
+
+Ini referensi kanonik cara kuota dihitung dan dipakai di [Coding Plan](/id/coding-plan/overview).
+
+## Apa yang Dihitung sebagai 1 Prompt
+
+Kuota **berbasis prompt, bukan token**. Satu prompt = **satu giliran user** di coding tool — berapa pun panggilan model yang dilakukan agent di balik layar.
+
+<Info>
+  Satu giliran "perbaiki bug ini" bisa memicu ~15–20 panggilan model secara internal (langkah reasoning, tool call, baca file). Seluruh giliran itu tetap dihitung **1 prompt**.
+</Info>
+
+**Contoh nyata:** Kamu minta agent *"refactor modul ini dan update test-nya."* Agent membaca 6 file, menjalankan test suite dua kali, dan melakukan 18 panggilan model. Kuotamu berkurang **1 prompt** (dikali multiplier model — lihat di bawah).
+
+## Jendela Kuota
+
+| Jendela | Perilaku |
+|---------|----------|
+| **Rolling 5 jam** | Reset otomatis 5 jam setelah pemakaian dimulai. |
+| **Mingguan** | Reset 7 hari sejak awal langganan. |
+
+- **Tanpa overage.** Saat kuota sebuah jendela habis, request di-hard-stop sampai reset.
+- **Tanpa potongan saldo.** Coding Plan tidak pernah memotong saldo PAYG-mu.
+
+## Tier Paket
+
+| Tier | Limit 5 Jam | Limit Mingguan | Harga |
+|------|-------------|----------------|-------|
+| Coding Hemat | ~80 prompt | ~400 prompt | Rp 149.000/bln |
+| Coding Reguler | ~400 prompt | ~2.000 prompt | Rp 499.000/bln |
+| Coding Eksklusif | ~1.600 prompt | ~8.000 prompt | Rp 1.290.000/bln |
+
+<Info>
+  Penggunaan aktual bervariasi tergantung kompleksitas proyek dan pilihan model.
+</Info>
+
+## Multiplier Model Berbasis Beban
+
+Setiap prompt memakai kuota sebesar multiplier model-nya. Model flagship makan lebih banyak saat upstream sedang **under load**. Beban dideteksi **dinamis per model** dari live capacity-error rate-nya pada rolling window — **bukan** jadwal jam tetap.
+
+| Kondisi | Model flagship | Model mid | Model ringan |
+|---------|----------------|-----------|--------------|
+| Normal | 2× | 2× | 1× |
+| Under load | 3× | 2× | 1× |
+
+<Note>
+  Hanya model flagship yang berpindah antara 2× dan 3×. Model mid tetap 2× dan model ringan tetap 1× berapa pun bebannya. "Under load" ditentukan dari kapasitas upstream tiap model secara live, bukan jendela jam.
+</Note>
+
+## Tips Hemat Kuota
+
+<Tip>
+  Pakai model ringan (`gemini-3-flash`, `glm-4.7-flash`) untuk tugas rutin — tetap 1×. Simpan model flagship (`claude-4.5-sonnet`, `claude-4.5-opus`) untuk reasoning kompleks dan refactor besar.
+</Tip>
+
+- Gabungkan perubahan terkait dalam satu giliran bila memungkinkan — lebih sedikit giliran, lebih sedikit prompt.
+- Ganti model per tugas alih-alih menjalankan semuanya di flagship. Lihat [Ganti Model](/id/coding-plan/switching-models).
+
+## Terkait
+
+- [Ganti Model](/id/coding-plan/switching-models) — pilih model yang tepat per tugas.
+- [Usage Policy](/id/coding-plan/usage-policy) — penegakan rate-limit dan fair use.

--- a/id/coding-plan/switching-models.mdx
+++ b/id/coding-plan/switching-models.mdx
@@ -1,0 +1,101 @@
+---
+title: "Ganti Model"
+description: "Cara ganti model di coding tool saat pakai Neosantara Coding Plan."
+---
+
+Neosantara Coding Plan memberimu akses ke semua model di gateway. Kamu bisa ganti model kapan saja tanpa mengubah langganan.
+
+## Sebelum Mulai
+
+Pastikan kamu sudah punya:
+1. **Langganan Coding Plan aktif** dan coding key (`nsk_code_*`) yang valid.
+2. **Endpoint coding yang benar** di konfigurasi tool.
+3. Setup dasar yang berfungsi (test dulu dengan prompt sederhana).
+
+## Model Tersedia
+
+Semua model di gateway Neosantara tersedia lewat Coding Plan. Pilihan populer untuk coding:
+
+| Model | Cocok untuk | Multiplier kuota |
+|-------|-------------|-----------------|
+| `claude-4.5-sonnet` | Coding kompleks, refactoring | 2× (normal), 3× (under load) |
+| `claude-4.5-opus` | Reasoning mendalam, arsitektur | 2× (normal), 3× (under load) |
+| `gemini-3-flash` | Iterasi cepat, tugas rutin | 1× |
+| `glm-4.7-flash` | Coding harian hemat | 1× |
+| `deepseek-r1` | Tugas reasoning-heavy | 1× |
+| `qwen3-32b` | Dukungan multi-bahasa | 1× |
+
+<Tip>
+  Pakai model ringan (`gemini-3-flash`, `glm-4.7-flash`) untuk tugas rutin dan switch ke model premium hanya untuk reasoning kompleks — ini memaksimalkan kuotamu.
+</Tip>
+
+## Ganti Model di Claude Code
+
+### Metode 1: Update settings.json
+
+Edit `~/.claude/settings.json` dan ganti variabel model:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "nsk_code_KEY_KAMU",
+    "ANTHROPIC_MODEL": "deepseek-r1",
+    "ANTHROPIC_SMALL_FAST_MODEL": "gemini-3-flash",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-4.5-sonnet",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-4.5-opus",
+    "API_TIMEOUT_MS": "3600000"
+  }
+}
+```
+
+### Metode 2: Pakai perintah /model
+
+Di sesi Claude Code aktif, ketik:
+
+```
+/model claude-4.5-opus
+```
+
+Ini ganti model untuk sesi saat ini tanpa edit file konfigurasi.
+
+### Verifikasi
+
+Ketik `/status` di Claude Code untuk konfirmasi model aktif.
+
+## Ganti Model di Cline
+
+1. Buka pengaturan Cline di VS Code
+2. Di bagian **Model**, ganti nama model (mis. `gemini-3-flash`)
+3. Perubahan langsung berlaku untuk pesan baru
+
+## Ganti Model di Continue / OpenCode
+
+Update field `model` di konfigurasi:
+
+```
+Base URL: https://api.neosantara.xyz/coding/v1
+API Key:  nsk_code_KEY_KAMU
+Model:    gemini-3-flash
+```
+
+## Ganti Model di Cursor
+
+1. Settings → Models
+2. Ganti nama model di konfigurasi custom model
+3. Atau tambah beberapa entry model dan pilih di chat
+
+## Rekomendasi Model per Tugas
+
+| Tugas | Model Rekomendasi | Alasan |
+|-------|-------------------|--------|
+| Quick fix, linting | `gemini-3-flash` | Cepat, hemat (1× kuota) |
+| Implementasi fitur | `claude-4.5-sonnet` | Keseimbangan speed dan kualitas |
+| Refactoring kompleks | `claude-4.5-opus` | Kapabilitas reasoning mendalam |
+| Debugging dengan konteks | `deepseek-r1` | Kuat di tracing logic |
+| Code review | `qwen3-32b` | Bagus untuk penjelasan |
+| Boilerplate rutin | `glm-4.7-flash` | Cepat dan hemat |
+
+## Multiplier Kuota Berbasis Beban
+
+Multiplier model (1× ringan, 2× mid/flagship, hingga 3× untuk flagship under load) menentukan berapa kuota yang dipakai tiap prompt. Lihat [Kuota & Limit](/id/coding-plan/quota-and-limits#multiplier-model-berbasis-beban) untuk rinciannya.

--- a/id/coding-plan/switching-models.mdx
+++ b/id/coding-plan/switching-models.mdx
@@ -1,63 +1,88 @@
 ---
 title: "Ganti Model"
-description: "Cara ganti model di coding tool saat pakai Neosantara Coding Plan."
+description: "Cara ganti model di coding tool saat memakai Neosantara Coding Plan."
 ---
 
-Neosantara Coding Plan memberimu akses ke semua model di gateway. Kamu bisa ganti model kapan saja tanpa mengubah langganan.
+Neosantara Coding Plan memberimu akses ke model di gateway sesuai tier-mu. Kamu bisa ganti model kapan saja tanpa mengubah langganan.
 
 ## Sebelum Mulai
 
-Pastikan kamu sudah punya:
-1. **Langganan Coding Plan aktif** dan coding key (`nsk_code_*`) yang valid.
-2. **Endpoint coding yang benar** di konfigurasi tool.
-3. Setup dasar yang berfungsi (test dulu dengan prompt sederhana).
+Pastikan kamu punya:
+1. **Langganan Coding Plan aktif** dan coding key yang valid (`nsk_code_*`).
+2. **Coding endpoint yang benar** sudah dikonfigurasi di tool-mu.
+3. Setup dasar yang berfungsi (tes dulu dengan prompt sederhana).
 
-## Model Tersedia
+## Cek Model yang Tersedia
 
-Semua model di gateway Neosantara tersedia lewat Coding Plan. Pilihan populer untuk coding:
+Model yang tersedia tergantung tier-mu dan bisa berubah kapan saja. Cek model yang diizinkan saat ini:
 
-| Model | Cocok untuk | Multiplier kuota |
-|-------|-------------|-----------------|
-| `claude-4.5-sonnet` | Coding kompleks, refactoring | 2× (normal), 3× (under load) |
-| `claude-4.5-opus` | Reasoning mendalam, arsitektur | 2× (normal), 3× (under load) |
-| `gemini-3-flash` | Iterasi cepat, tugas rutin | 1× |
-| `glm-4.7-flash` | Coding harian hemat | 1× |
-| `deepseek-r1` | Tugas reasoning-heavy | 1× |
-| `qwen3-32b` | Dukungan multi-bahasa | 1× |
+**Dari dashboard:**
+Buka [Coding Plan](https://app.neosantara.xyz/coding-plan) → tab "Overview" menampilkan model yang diizinkan.
 
-<Tip>
-  Pakai model ringan (`gemini-3-flash`, `glm-4.7-flash`) untuk tugas rutin dan switch ke model premium hanya untuk reasoning kompleks — ini memaksimalkan kuotamu.
-</Tip>
+**Dari CLI:**
+```bash
+jelma models
+```
+
+**Dari API:**
+```bash
+curl https://api.neosantara.xyz/coding/v1/models \
+  -H "Authorization: Bearer nsk_code_KEY_KAMU"
+```
+
+<Note>
+  Daftar model kosong berarti **semua model** di gateway tersedia. Tier lebih tinggi membuka lebih banyak model, termasuk model frontier dengan multiplier kuota lebih tinggi.
+</Note>
 
 ## Ganti Model di Claude Code
 
 ### Metode 1: Update settings.json
 
-Edit `~/.claude/settings.json` dan ganti variabel model:
+Edit `~/.claude/settings.json` dan ganti modelnya:
 
 ```json
 {
   "env": {
     "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
     "ANTHROPIC_AUTH_TOKEN": "nsk_code_KEY_KAMU",
-    "ANTHROPIC_MODEL": "deepseek-r1",
-    "ANTHROPIC_SMALL_FAST_MODEL": "gemini-3-flash",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-4.5-sonnet",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-4.5-opus",
-    "API_TIMEOUT_MS": "3600000"
+    "ANTHROPIC_MODEL": "garda-core"
+  }
+}
+```
+
+Claude Code memakai beberapa slot model. Override semua agar setiap request melewati model pilihanmu (atau [Model Route](/id/coding-plan/model-routes)-mu):
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "nsk_code_KEY_KAMU",
+    "ANTHROPIC_MODEL": "garda-core",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "garda-core",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "garda-core",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "garda-core",
+    "ANTHROPIC_SMALL_FAST_MODEL": "garda-core"
   }
 }
 ```
 
 ### Metode 2: Pakai perintah /model
 
-Di sesi Claude Code aktif, ketik:
+Di sesi Claude Code yang aktif, ketik:
 
 ```
-/model claude-4.5-opus
+/model deepseek-v4-flash
 ```
 
-Ini ganti model untuk sesi saat ini tanpa edit file konfigurasi.
+Ini mengganti model untuk sesi saat ini tanpa mengedit file config.
+
+### Metode 3: Pakai Jelma
+
+Jelma men-set semua slot model otomatis:
+
+```bash
+jelma claude local --model deepseek-v4-flash
+```
 
 ### Verifikasi
 
@@ -66,36 +91,60 @@ Ketik `/status` di Claude Code untuk konfirmasi model aktif.
 ## Ganti Model di Cline
 
 1. Buka pengaturan Cline di VS Code
-2. Di bagian **Model**, ganti nama model (mis. `gemini-3-flash`)
+2. Di bagian **Model**, ganti nama model
 3. Perubahan langsung berlaku untuk pesan baru
 
 ## Ganti Model di Continue / OpenCode
 
-Update field `model` di konfigurasi:
+Update field `model` di konfigurasimu:
 
 ```
 Base URL: https://api.neosantara.xyz/coding/v1
 API Key:  nsk_code_KEY_KAMU
-Model:    gemini-3-flash
+Model:    deepseek-v4-flash
+```
+
+## Ganti Model di Codex CLI
+
+Edit `~/.codex/config.toml`:
+
+```toml
+model = "deepseek-v4-flash"
+```
+
+Atau pakai Jelma:
+```bash
+jelma codex local --model deepseek-v4-flash
 ```
 
 ## Ganti Model di Cursor
 
 1. Settings → Models
-2. Ganti nama model di konfigurasi custom model
+2. Ganti nama model di konfigurasi custom model-mu
 3. Atau tambah beberapa entry model dan pilih di chat
 
-## Rekomendasi Model per Tugas
+## Pakai Model Routes (Direkomendasikan)
 
-| Tugas | Model Rekomendasi | Alasan |
-|-------|-------------------|--------|
-| Quick fix, linting | `gemini-3-flash` | Cepat, hemat (1× kuota) |
-| Implementasi fitur | `claude-4.5-sonnet` | Keseimbangan speed dan kualitas |
-| Refactoring kompleks | `claude-4.5-opus` | Kapabilitas reasoning mendalam |
-| Debugging dengan konteks | `deepseek-r1` | Kuat di tracing logic |
-| Code review | `qwen3-32b` | Bagus untuk penjelasan |
-| Boilerplate rutin | `glm-4.7-flash` | Cepat dan hemat |
+Daripada mengganti nama model secara manual, buat [Model Route](/id/coding-plan/model-routes) — alias virtual yang resolve ke chain model dengan failover otomatis:
 
-## Multiplier Kuota Berbasis Beban
+```bash
+# Setup sekali di dashboard, lalu pakai di mana-mana:
+jelma claude local --model my-coder
+```
 
-Multiplier model (1× ringan, 2× mid/flagship, hingga 3× untuk flagship under load) menentukan berapa kuota yang dipakai tiap prompt. Lihat [Kuota & Limit](/id/coding-plan/quota-and-limits#multiplier-model-berbasis-beban) untuk rinciannya.
+Keuntungan:
+- **Tanpa ganti config** saat mau switch — cukup update route di dashboard
+- **Failover otomatis** jika model utama tidak tersedia
+- **Nama konsisten** di semua tool dan mesin
+
+## Pertimbangan Kuota
+
+- **Model ringan** (multiplier 1×) — terbaik untuk task rutin, hemat kuota
+- **Model mid-tier** (multiplier 2×) — balance kualitas dan biaya
+- **Model frontier** (hingga 3× saat under load) — pakai selektif untuk task kompleks
+
+Multiplier pastinya tergantung load gateway saat itu. Cek [Kuota & Limit](/id/coding-plan/quota-and-limits) untuk detail.
+
+<Tip>
+  Pakai model ringan untuk quick fix dan code generation. Switch ke model premium hanya untuk reasoning kompleks, keputusan arsitektur, atau refactoring multi-file. Strategi ini bisa 2–3× kuota efektifmu.
+</Tip>

--- a/id/coding-plan/tool-integration.mdx
+++ b/id/coding-plan/tool-integration.mdx
@@ -1,0 +1,105 @@
+---
+title: "Integrasi Tool"
+description: "Tool coding yang didukung dan panduan konfigurasi untuk Neosantara Coding Plan."
+---
+
+## Tool yang Didukung
+
+Neosantara Coding Plan bisa dipakai di tool coding apa pun yang mendukung protokol API **OpenAI** atau **Anthropic**.
+
+### Coding Agent
+
+<CardGroup cols={2}>
+  <Card title="Claude Code">CLI coding agent dari Anthropic. Pakai protokol Anthropic.</Card>
+  <Card title="Cline">Ekstensi VS Code. Pakai protokol OpenAI-compatible.</Card>
+  <Card title="Continue">Ekstensi VS Code dan JetBrains. OpenAI-compatible.</Card>
+  <Card title="OpenCode">Terminal-based coding agent. OpenAI-compatible.</Card>
+  <Card title="Cursor">Editor AI-first dengan dukungan model custom.</Card>
+  <Card title="Jelma">Coding agent bawaan Neosantara — tanpa setup lokal.</Card>
+</CardGroup>
+
+### Tool Agent Umum
+
+Tool apa pun yang mendukung OpenAI Chat Completions atau Anthropic Messages API bisa pakai Coding Plan, termasuk:
+- Roo Code, Kilo Code, Goose, Crush
+- Script custom pakai OpenAI SDK atau Anthropic SDK
+
+## Endpoint Coding
+
+| Protokol | Base URL | Kapan dipakai |
+|----------|----------|---------------|
+| Anthropic Messages | `https://api.neosantara.xyz/coding/anthropic` | Claude Code, Goose, atau tool format Anthropic |
+| OpenAI Chat Completions | `https://api.neosantara.xyz/coding/v1` | Cline, Continue, OpenCode, Cursor, dan kebanyakan tool lain |
+
+<Warning>
+  **Penting:** Coding key (`nsk_code_*`) hanya bisa dipakai di endpoint coding khusus ini. Mengirim ke `/v1` atau `/anthropic` (endpoint PAYG) akan return `403`.
+</Warning>
+
+## Contoh Konfigurasi
+
+### Claude Code (protokol Anthropic)
+
+Edit `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.neosantara.xyz/coding/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "nsk_code_KEY_KAMU",
+    "ANTHROPIC_MODEL": "claude-4.5-sonnet",
+    "ANTHROPIC_SMALL_FAST_MODEL": "gemini-3-flash",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-4.5-sonnet",
+    "API_TIMEOUT_MS": "3600000"
+  }
+}
+```
+
+<Note>
+  Hapus variabel environment `ANTHROPIC_AUTH_TOKEN` atau `ANTHROPIC_BASE_URL` yang sudah ada sebelum konfigurasi, agar tidak konflik.
+</Note>
+
+### Cline (protokol OpenAI-compatible)
+
+1. Buka VS Code → Extensions → Pengaturan Cline
+2. Pilih **API Provider**: `OpenAI Compatible`
+3. Isi:
+   - **Base URL**: `https://api.neosantara.xyz/coding/v1`
+   - **API Key**: `nsk_code_KEY_KAMU`
+   - **Model**: `claude-4.5-sonnet` (atau model lain dari tier-mu)
+4. Uncheck **Support Images**
+5. Set **Context Window Size** sesuai model (mis. `200000`, atau `1000000` untuk Gemini)
+
+### Continue / OpenCode
+
+```
+Base URL: https://api.neosantara.xyz/coding/v1
+API Key:  nsk_code_KEY_KAMU
+Model:    claude-4.5-sonnet
+```
+
+### Cursor
+
+1. Settings → Models → Add Custom Model
+2. **OpenAI Base URL**: `https://api.neosantara.xyz/coding/v1`
+3. **API Key**: `nsk_code_KEY_KAMU`
+4. **Model name**: `claude-4.5-sonnet`
+
+### Jelma (Tanpa Konfigurasi)
+
+Buka [Jelma](https://app.neosantara.xyz/jelma) di dashboard. Pilih coding agent dan mulai — otomatis pakai coding key dan endpoint coding.
+
+## Verifikasi Setup
+
+Setelah konfigurasi, test dengan prompt sederhana:
+
+```
+Berapa 2 + 2? Jawab angka saja.
+```
+
+Jika dapat response, Coding Plan-mu aktif dan terkonfigurasi benar. Jika error:
+
+| Error | Solusi |
+|-------|--------|
+| `403 coding_key_requires_coding_endpoint` | Base URL salah. Ganti ke `/coding/v1` atau `/coding/anthropic`. |
+| `401 Unauthorized` | Cek API key — harus dimulai dengan `nsk_code_`. |
+| `429 rate_limit_exceeded` | Kuota 5 jam atau mingguan habis. Tunggu window reset. |

--- a/id/coding-plan/usage-policy.mdx
+++ b/id/coding-plan/usage-policy.mdx
@@ -1,0 +1,40 @@
+---
+title: "Kebijakan Penggunaan"
+description: "Aturan dan pedoman fair-use untuk Neosantara Coding Plan."
+---
+
+## Penggunaan yang Diizinkan
+
+Neosantara Coding Plan ditujukan secara eksklusif untuk **pengembangan software berbantuan AI** menggunakan coding tool yang didukung. Kamu menyetujui hal berikut:
+
+1. **Hanya tool yang didukung** — Plan hanya boleh dipakai dengan coding agent yang berkomunikasi via endpoint `/coding/v1` atau `/coding/anthropic` (mis. Claude Code, Cline, Continue, OpenCode, Jelma).
+2. **Dilarang abuse otomasi** — Script otomatis yang menggelembungkan jumlah prompt atau menghindari rate limit dilarang.
+3. **Satu user per key** — Coding key bersifat personal. Berbagi key antar user atau organisasi tidak diperbolehkan.
+4. **Dilarang jual ulang** — Menjual kembali akses atau mem-proxy endpoint coding untuk pihak ketiga dilarang.
+
+## Rate Limit
+
+| Jendela | Enforcement |
+|---------|-------------|
+| Rolling 5 jam | Hard-stop saat kuota habis; reset otomatis setelah 5 jam |
+| Mingguan | Hard-stop saat kuota mingguan habis; reset 7 hari dari awal langganan |
+
+- Tanpa billing overage — request cukup diblokir sampai window reset.
+- Multiplier model flagship naik ke 3× (dari 2× normal) saat model sedang under load, dideteksi dinamis dari kapasitas upstream.
+
+## Tindakan Akun
+
+Neosantara berhak untuk:
+- Menangguhkan atau menghentikan akses coding plan jika melanggar kebijakan.
+- Menyesuaikan batas kuota dengan pemberitahuan 7 hari jika terdeteksi penyalahgunaan.
+- Mencabut key yang dibagikan secara publik atau digunakan dalam otomasi tidak sah.
+
+## Refund
+
+Invoice Coding Plan **tidak bisa di-refund** setelah dibayar. Jika Kamu mengalami masalah teknis yang mencegah penggunaan, hubungi support@neosantara.xyz dalam 48 jam setelah pembelian.
+
+## Data & Privasi
+
+- Traffic Coding Plan tunduk pada [Kebijakan Privasi](https://www.neosantara.xyz/privacy) yang sama dengan semua layanan Neosantara.
+- Kami tidak melatih model dari kode atau prompt-mu.
+- Log request disimpan hanya untuk verifikasi billing dan deteksi penyalahgunaan.

--- a/id/guides/jelma/best-practices.mdx
+++ b/id/guides/jelma/best-practices.mdx
@@ -1,0 +1,154 @@
+---
+title: "Best Practice"
+description: "Tips memaksimalkan Jelma — pemilihan model, manajemen kuota, keamanan, dan optimisasi workflow."
+---
+
+## Pemilihan Model
+
+### Pakai Model Routes untuk konsistensi
+
+Buat [Model Route](/id/coding-plan/model-routes) daripada hardcode nama model. Ini memberimu:
+- **Failover otomatis** — kalau model utama rate-limited, model berikutnya di chain mengambil alih
+- **Ganti mudah** — ubah chain di dashboard tanpa menyentuh config agent
+- **Penamaan konsisten** — pakai `my-coder` di mana-mana, resolve ke model berbeda per task
+
+```bash
+# Command sama, model di-resolve oleh config route-mu
+jelma claude local --model my-coder
+jelma codex hetzner --model my-coder
+```
+
+### Cocokkan model dengan kompleksitas task
+
+| Task | Pendekatan rekomendasi |
+|------|------------------------|
+| Fix sederhana, formatting | Model ringan (DeepSeek Flash, GLM Flash) |
+| Refactoring multi-file | `garda-core` atau model premium |
+| Reasoning kompleks | Model premium di posisi pertama route chain |
+| Task CI rutin | Model termurah untuk hemat kuota |
+
+### Hemat kuota dengan model ringan
+
+Kuota Coding Plan dikonsumsi per prompt, tapi model premium bisa 2–3× saat jam sibuk. Pakai model ringan untuk task rutin:
+
+```bash
+jelma codex local --model deepseek-v4-flash  # Cepat + murah
+```
+
+## Keamanan
+
+### Jangan commit kredensial
+
+Jelma menyimpan kredensial di `~/.config/jelma/`. Jangan commit direktori ini. Kalau pakai file `--config`, exclude dari git:
+
+```bash
+echo "*.jelma-config.json" >> .gitignore
+```
+
+### Pakai environment variable untuk CI/CD
+
+```bash
+NEOSANTARA_API_KEY="$SECRET" \
+HCLOUD_TOKEN="$HCLOUD_SECRET" \
+jelma claude hetzner --headless --output json --prompt "Run tests"
+```
+
+### Bersihkan resource cloud
+
+Selalu hapus VM setelah selesai:
+```bash
+jelma status          # Cek apa yang sedang jalan
+jelma delete          # Cleanup interaktif
+jelma status --prune  # Hapus entri stale dari history
+```
+
+## Tips Workflow
+
+### Pakai `--fast` untuk iterative development
+
+Saat spin up agent berulang-ulang (testing config, debugging), `--fast` menghemat menit per peluncuran:
+
+```bash
+jelma claude hetzner --fast --prompt "Fix the failing test"
+```
+
+### Mode headless untuk automasi
+
+Integrasikan Jelma ke script dan pipeline CI:
+
+```bash
+result=$(jelma claude local \
+  --headless \
+  --output json \
+  --prompt "Analisis codebase ini dan list semua TODO")
+
+echo "$result" | jq '.output'
+```
+
+### Pakai `jelma fix` daripada re-provisioning
+
+Kalau config agent rusak atau kredensial expired, jangan hapus dan buat ulang:
+
+```bash
+jelma fix  # Re-inject kredensial, jalankan ulang setup agent
+```
+
+### Preferensi persisten
+
+Set default model per-agent di `~/.config/spawn/preferences.json`:
+
+```json
+{
+  "models": {
+    "claude": "my-coder",
+    "codex": "garda-core",
+    "openclaw": "garda-core"
+  }
+}
+```
+
+Sekarang `jelma claude local` selalu pakai `my-coder` tanpa `--model`.
+
+## Tips Cloud-Specific
+
+### Hetzner (termurah)
+
+Harga/performa terbaik untuk development. Pakai `--zone` untuk pilih datacenter terdekat:
+
+```bash
+jelma claude hetzner --zone fsn1  # Falkenstein, Jerman
+jelma claude hetzner --zone sin1  # Singapura
+```
+
+### Lokal (iterasi tercepat)
+
+Tanpa delay provisioning. Pakai untuk iterasi cepat:
+
+```bash
+jelma claude local --prompt "Fix this bug"
+jelma last  # Jalankan ulang instan dengan config sama
+```
+
+### Rekursif untuk task kompleks
+
+Biarkan agent spawn child agent untuk subtask paralel:
+
+```bash
+jelma claude hetzner --beta recursive --prompt "Refactor seluruh modul auth"
+```
+
+Agent parent bisa pakai `jelma` di dalam VM untuk spawn helper.
+
+## Anti-Pattern
+
+<Warning>
+  Hindari kesalahan umum ini:
+</Warning>
+
+| Jangan | Lakukan ini |
+|--------|------------|
+| Biarkan VM jalan semalaman | `jelma delete` setelah selesai |
+| Hardcode nama model di script | Pakai Model Routes atau `preferences.json` |
+| Pakai model premium untuk semua | Cocokkan model dengan kompleksitas task |
+| Skip `--dry-run` di cloud mahal | Selalu preview dulu di setup yang belum familiar |
+| Simpan API key di file config | Pakai environment variable |

--- a/id/guides/jelma/faq.mdx
+++ b/id/guides/jelma/faq.mdx
@@ -1,0 +1,140 @@
+---
+title: "FAQ"
+description: "Pertanyaan yang sering ditanyakan tentang Jelma — instalasi, agent, billing, dan troubleshooting."
+---
+
+## Instalasi
+
+<AccordionGroup>
+  <Accordion title="Apa syarat sistemnya?">
+    - **bun >= 1.2.0** (installer mengurus ini)
+    - macOS, Linux, atau Windows (WSL2 atau PowerShell)
+    - Koneksi internet untuk download agent
+  </Accordion>
+
+  <Accordion title="Cara update Jelma?">
+    ```bash
+    jelma update
+    ```
+    Atau install ulang:
+    ```bash
+    curl -fsSL https://cli.neosantara.xyz/install.sh | bash
+    ```
+  </Accordion>
+
+  <Accordion title="Di mana Jelma menyimpan data?">
+    - **Config**: `~/.config/jelma/` (kredensial, preferensi)
+    - **History**: `~/.config/jelma/history.json`
+    - **Config agent**: Ditulis ke lokasi standar per agent (`~/.claude/settings.json`, `~/.codex/config.toml`, dll.)
+  </Accordion>
+
+  <Accordion title="Cara uninstall?">
+    ```bash
+    jelma uninstall
+    ```
+    Ini menghapus binary CLI dan opsional membersihkan `~/.config/jelma`.
+  </Accordion>
+</AccordionGroup>
+
+## Agent & Cloud
+
+<AccordionGroup>
+  <Accordion title="Agent mana yang sebaiknya dipakai?">
+    - **Claude Code** — Kapabilitas agentic terbaik secara keseluruhan, kuat di task multi-file kompleks
+    - **Codex CLI** — Cepat, ringan, bagus untuk fix cepat
+    - **OpenClaw** — Terbaik untuk task yang butuh browser (web scraping, testing)
+    - **OpenCode** — Alternatif open-source, bagus untuk task sederhana
+    - **Hermes** — Orientasi riset, reasoning kuat
+    - **Pi** — Minimal dan cepat untuk task kecil
+  </Accordion>
+
+  <Accordion title="Bisa pakai Jelma tanpa cloud?">
+    Bisa. Pilih `local` sebagai target cloud:
+    ```bash
+    jelma claude local
+    ```
+    Ini menjalankan agent langsung di mesinmu tanpa provisioning cloud.
+  </Accordion>
+
+  <Accordion title="Resource cloud apa yang dibuat Jelma?">
+    Satu VM (ukuran terkecil yang tersedia secara default). Jelma mem-provisioning, mengonfigurasi, dan memberimu akses SSH. Kamu bertanggung jawab menghapusnya:
+    ```bash
+    jelma delete
+    ```
+  </Accordion>
+
+  <Accordion title="Cara pakai model kustom?">
+    Pakai `--model` dengan model apa pun yang tersedia di plan-mu:
+    ```bash
+    jelma claude local --model deepseek-v4-flash
+    ```
+    User Coding Plan bisa membuat [Model Routes](/id/coding-plan/model-routes) untuk nama virtual dengan failover:
+    ```bash
+    jelma claude local --model my-coder
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Billing
+
+<AccordionGroup>
+  <Accordion title="Bagaimana billing-nya?">
+    Jelma mendukung dua mode:
+    - **PAYG**: API key biasa, ditagih per token dari saldo
+    - **Coding Plan**: Coding key (`nsk_code_*`), ditagih dari kuota prompt
+
+    Jelma mendeteksi tipe key-mu dan routing ke endpoint yang benar secara otomatis.
+  </Accordion>
+
+  <Accordion title="Apakah menjalankan Jelma ada biaya selain model usage?">
+    CLI Jelma sendiri gratis. Model usage ditagih melalui akun Neosantara-mu. Resource cloud (VM) ditagih oleh provider cloud sesuai tarif standar mereka.
+  </Accordion>
+
+  <Accordion title="Apa itu garda-core?">
+    `garda-core` adalah model eksperimental Neosantara dengan context window 1M token. Ini model default yang dipakai Jelma. User Coding Plan bisa override dengan `--model` atau mengonfigurasi [Model Route](/id/coding-plan/model-routes) yang me-resolve `garda-core` ke failover chain kustom.
+  </Accordion>
+</AccordionGroup>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Agent gagal install di VM cloud">
+    Penyebab umum:
+    1. **Timeout jaringan** — Coba lagi; mirror paket bisa lambat
+    2. **Kredensial kurang** — Pastikan kredensial cloud sudah di-set
+    3. **Masalah region** — Coba `--zone` dengan region berbeda
+
+    Pakai `--dry-run` untuk preview apa yang Jelma akan lakukan sebelum provisioning.
+  </Accordion>
+
+  <Accordion title="Error 'Model not found'">
+    Model-mu tidak tersedia di plan-mu. Cek model yang tersedia:
+    ```bash
+    jelma models
+    ```
+    Untuk user Coding Plan, pastikan model ada di daftar yang diizinkan tier-mu.
+  </Accordion>
+
+  <Accordion title="Claude Code langsung exit di mode headless">
+    Kamu harus kasih `--prompt` saat pakai `--headless`:
+    ```bash
+    # Salah — Claude langsung exit
+    jelma claude gcp --headless --output json
+
+    # Benar
+    jelma claude gcp --headless --output json --prompt "Fix linter errors"
+    ```
+  </Accordion>
+
+  <Accordion title="Error 'coding_key_requires_coding_endpoint'">
+    Coding key-mu (`nsk_code_*`) mengarah ke endpoint PAYG. Ini seharusnya tidak terjadi dengan Jelma (auto-route), tapi kalau pakai config manual pastikan base URL adalah `/coding/v1` atau `/coding/anthropic`.
+  </Accordion>
+
+  <Accordion title="Cara dapat bantuan?">
+    ```bash
+    jelma help
+    jelma feedback "jelaskan masalahmu"
+    ```
+    Atau buka issue: [github.com/neosantara-xyz/jelma/issues](https://github.com/neosantara-xyz/jelma/issues)
+  </Accordion>
+</AccordionGroup>

--- a/id/guides/jelma/overview.mdx
+++ b/id/guides/jelma/overview.mdx
@@ -1,0 +1,85 @@
+---
+title: "Jelma Overview"
+description: "Luncurkan AI coding agent apa pun di cloud mana pun cukup dengan satu perintah. 9 agen, 8 cloud, tanpa config — semua model ditenagai Neosantara."
+---
+
+## Apa itu Jelma?
+
+**Jelma** adalah tool CLI Neosantara yang men-deploy AI coding agent ke mana saja — mesinmu sendiri, AWS, GCP, Hetzner, DigitalOcean, Daytona, E2B, atau Sprite — dengan satu perintah. Jelma menangani injeksi kredensial, konfigurasi model, dan setup agent agar kamu bisa langsung coding.
+
+<Warning>
+  Jelma masih **alpha**. Saat dijalankan di cloud, ia membuat resource sungguhan di akunmu. Tinjau output dan gunakan dengan risiko sendiri.
+</Warning>
+
+## Kenapa Jelma?
+
+| Tanpa Jelma | Dengan Jelma |
+|-------------|-------------|
+| Edit settings.json, env var, config file manual | Satu perintah — semua diinjeksi |
+| Ingat base URL per protokol per billing mode | Dipilih otomatis |
+| Tempel API key ke tiap tool | Jelma memakai key-mu untukmu |
+| Ulangi di tiap mesin/agent | `jelma <agent> <cloud>` di mana saja |
+
+## Agent yang Didukung
+
+| Agent | Deskripsi |
+|-------|-----------|
+| **Claude Code** | CLI coding agentic dari Anthropic |
+| **Codex CLI** | Coding agent terminal dari OpenAI |
+| **OpenClaw** | TUI coding dengan integrasi browser Chrome |
+| **OpenCode** | Coding agent terminal open-source |
+| **Kilo Code** | CLI coding agent AI open-source |
+| **Hermes** | CLI agentic dari Nous Research |
+| **Junie** | Coding agent dari JetBrains |
+| **Cursor CLI** | Coding agent terminal dari Cursor |
+| **Pi** | Coding agent terminal ringan |
+
+## Cloud yang Didukung
+
+| Cloud | Metode auth |
+|-------|-------------|
+| **Mesin Lokal** | Tidak perlu kredensial cloud |
+| **AWS Lightsail** | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
+| **Google Cloud** | `gcloud auth` |
+| **Hetzner** | `HCLOUD_TOKEN` |
+| **DigitalOcean** | `DIGITALOCEAN_ACCESS_TOKEN` |
+| **Daytona** | `DAYTONA_API_KEY` |
+| **E2B** | `E2B_API_KEY` |
+| **Sprite** | `sprite login` |
+
+## Mode Billing
+
+Jelma mendukung dua mode billing:
+
+- **Pay-As-You-Go (PAYG)** — Pakai API key biasa. Ditagih per token dari saldo akun. Endpoint: `/v1`, `/anthropic`.
+- **Coding Plan** — Pakai coding key (`nsk_code_*`). Ditagih dari kuota prompt (jendela 5 jam + mingguan). Endpoint: `/coding/v1`, `/coding/anthropic`.
+
+Jelma otomatis routing ke base URL yang benar berdasarkan tipe key-mu.
+
+## Model Routing
+
+Secara default, Jelma memakai `garda-core` — model eksperimental Neosantara dengan context window 1M. Override dengan `--model`:
+
+```bash
+jelma claude local --model my-custom-route
+```
+
+User Coding Plan bisa membuat [Model Routes](/id/coding-plan/model-routes) di dashboard untuk nama virtual dengan failover chain otomatis.
+
+## Quick Start
+
+```bash
+# Install
+curl -fsSL https://cli.neosantara.xyz/install.sh | bash
+
+# Luncurkan interaktif
+jelma
+
+# Luncurkan langsung
+jelma claude local
+jelma codex hetzner --model garda-core
+```
+
+<Card title="Selanjutnya: Panduan Penggunaan" icon="arrow-right" href="/id/guides/jelma/usage">
+  Pelajari semua command, flag, dan workflow.
+</Card>

--- a/id/guides/jelma/reference.mdx
+++ b/id/guides/jelma/reference.mdx
@@ -1,0 +1,129 @@
+---
+title: "Referensi Command"
+description: "Referensi lengkap semua command dan flag Jelma CLI."
+---
+
+## Command
+
+| Command | Deskripsi |
+|---------|-----------|
+| `jelma` | Picker interaktif agent + cloud |
+| `jelma <agent> <cloud>` | Luncurkan agent di cloud langsung |
+| `jelma <agent>` | Tampilkan cloud yang tersedia untuk agent |
+| `jelma <cloud>` | Tampilkan agent yang tersedia untuk cloud |
+| `jelma matrix` | Matriks kompatibilitas agent × cloud |
+| `jelma agents` | List semua agent dengan deskripsi |
+| `jelma clouds` | List semua provider cloud |
+| `jelma models` | List model yang tersedia untuk tipe key-mu |
+| `jelma list` | Telusuri instance sebelumnya |
+| `jelma tree` | Tampilkan spawn tree rekursif |
+| `jelma last` | Jalankan ulang instance terakhir |
+| `jelma delete` | Hapus server cloud secara interaktif |
+| `jelma status` | Tampilkan status live server cloud |
+| `jelma fix` | Jalankan ulang setup agent di VM yang ada |
+| `jelma link <ip>` | Daftarkan VM yang ada berdasarkan IP |
+| `jelma update` | Cek update CLI |
+| `jelma uninstall` | Uninstall Jelma CLI |
+| `jelma feedback "msg"` | Kirim feedback |
+| `jelma help` | Tampilkan bantuan |
+| `jelma version` | Tampilkan versi |
+
+## Flag Peluncuran
+
+| Flag | Singkat | Deskripsi |
+|------|---------|-----------|
+| `--prompt "text"` | `-p` | Prompt non-interaktif |
+| `--prompt-file <path>` | `-f` | Prompt dari file |
+| `--model <id>` | `-m` | Override model (mis. `garda-core`, `my-route`) |
+| `--headless` | | Provisioning lalu exit (tanpa sesi interaktif) |
+| `--output json` | | Output JSON di stdout (butuh `--headless`) |
+| `--dry-run` | | Preview tanpa provisioning |
+| `--zone <zone>` | | Set region/zone |
+| `--size <type>` | | Set ukuran/tipe instance |
+| `--config <file>` | | Load opsi dari JSON config |
+| `--steps <list>` | | Setup steps dipisah koma |
+| `--custom` | | Tampilkan picker ukuran/region interaktif |
+| `--fast` | | Aktifkan semua optimisasi kecepatan |
+| `--beta <feature>` | | Aktifkan fitur beta spesifik (bisa diulang) |
+| `--name <name>` | | Set nama instance kustom |
+
+## Flag List / Delete / Status
+
+| Flag | Singkat | Deskripsi |
+|------|---------|-----------|
+| `-a <agent>` | | Filter berdasarkan agent |
+| `-c <cloud>` | | Filter berdasarkan cloud |
+| `--flat` | | List datar (nonaktifkan tree view) |
+| `--json` | | Output sebagai JSON |
+| `--clear` | | Hapus semua history |
+| `--prune` | | Hapus server yang gone dari history |
+| `--name <name>` | | Target berdasarkan nama (untuk delete) |
+| `--yes` | | Lewati konfirmasi (untuk delete) |
+| `--cascade` | | Hapus VM dan semua child-nya |
+
+## Environment Variable
+
+| Variable | Deskripsi |
+|----------|-----------|
+| `NEOSANTARA_API_KEY` | API key Neosantara (PAYG atau coding) |
+| `JELMA_NO_COLOR` | Nonaktifkan output berwarna |
+| `JELMA_NO_UNICODE` | Nonaktifkan karakter Unicode |
+| `JELMA_NO_UPDATE_CHECK` | Lewati cek auto-update |
+| `JELMA_PARENT_ID` | ID instance parent (mode rekursif) |
+| `JELMA_DEPTH` | Kedalaman rekursi (mode rekursif) |
+
+## Setup Steps
+
+Kontrol setup opsional dengan `--steps`:
+
+```bash
+jelma openclaw gcp --steps github,browser
+jelma claude gcp --steps ""  # Lewati semua step opsional
+```
+
+| Step | Agent | Deskripsi |
+|------|-------|-----------|
+| `github` | Semua | GitHub CLI + git identity |
+| `reuse-api-key` | Semua | Pakai ulang key Neosantara yang tersimpan |
+| `browser` | OpenClaw | Browser Chrome (~400 MB) |
+| `telegram` | OpenClaw | Integrasi bot Telegram |
+| `whatsapp` | OpenClaw | Linking WhatsApp (QR interaktif) |
+
+## Identifier Agent
+
+Gunakan nama-nama ini sebagai `<agent>`:
+
+| ID | Agent |
+|----|-------|
+| `claude` | Claude Code |
+| `codex` | Codex CLI |
+| `openclaw` | OpenClaw |
+| `opencode` | OpenCode |
+| `kilocode` | Kilo Code |
+| `hermes` | Hermes |
+| `junie` | Junie |
+| `cursor` | Cursor CLI |
+| `pi` | Pi |
+
+## Identifier Cloud
+
+Gunakan nama-nama ini sebagai `<cloud>`:
+
+| ID | Cloud |
+|----|-------|
+| `local` | Mesinmu sendiri |
+| `aws` | AWS Lightsail |
+| `gcp` | Google Cloud Compute Engine |
+| `hetzner` | Hetzner Cloud |
+| `digitalocean` | DigitalOcean |
+| `daytona` | Daytona |
+| `e2b` | E2B |
+| `sprite` | Sprite |
+
+## Exit Code
+
+| Code | Arti |
+|------|------|
+| `0` | Sukses |
+| `1` | Error umum (provisioning gagal, agent crash) |
+| `130` | Interupsi user (Ctrl+C) |

--- a/id/guides/jelma/usage.mdx
+++ b/id/guides/jelma/usage.mdx
@@ -1,0 +1,181 @@
+---
+title: "Penggunaan"
+description: "Panduan lengkap menggunakan Jelma — install, jalankan agent, konfigurasi model, dan kelola instance cloud."
+---
+
+## Instalasi
+
+<Tabs>
+  <Tab title="macOS / Linux / WSL">
+    ```bash
+    curl -fsSL https://cli.neosantara.xyz/install.sh | bash
+    ```
+  </Tab>
+  <Tab title="Windows PowerShell">
+    ```powershell
+    irm https://cli.neosantara.xyz/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
+
+Butuh **bun >= 1.2.0**. Installer mengurus bun kalau belum ada.
+
+## Penggunaan Dasar
+
+```bash
+# Picker interaktif (agent → cloud → billing mode)
+jelma
+
+# Luncurkan langsung
+jelma <agent> <cloud>
+
+# Contoh
+jelma claude local                         # Claude Code di mesinmu
+jelma codex hetzner                        # Codex CLI di Hetzner
+jelma openclaw sprite --prompt "Fix bugs"  # Non-interaktif dengan prompt
+```
+
+## Kredensial
+
+Jelma meminta kredensial saat pertama kali jalan dan menyimpannya di `~/.config/jelma`:
+
+```bash
+# Key Neosantara (wajib — menenagai model)
+export NEOSANTARA_API_KEY="nsk_code_KEY_KAMU"
+
+# Kredensial cloud (hanya untuk deploy cloud)
+export HCLOUD_TOKEN="..."              # Hetzner
+export DIGITALOCEAN_ACCESS_TOKEN="..." # DigitalOcean
+export AWS_ACCESS_KEY_ID="..."         # AWS
+```
+
+## Pemilihan Model
+
+Model default adalah `garda-core` (context 1M, eksperimental). Override dengan `--model`:
+
+```bash
+# Pakai model spesifik
+jelma claude local --model deepseek-v4-flash
+
+# Pakai Model Route kustom (Coding Plan)
+jelma claude local --model my-coder
+
+# Semua slot model (utama, background, fast) pakai nama yang sama
+# Gateway resolve via failover chain-mu
+```
+
+Set preferensi model per-agent di `~/.config/spawn/preferences.json`:
+
+```json
+{
+  "models": {
+    "claude": "my-coder",
+    "codex": "garda-core"
+  }
+}
+```
+
+## Mode Non-Interaktif
+
+Lewati semua prompt dengan flag + env var:
+
+```bash
+jelma claude hetzner \
+  --prompt "Fix all linter errors" \
+  --headless \
+  --output json
+```
+
+Flag:
+- `--prompt "text"` / `-p "text"` — Kirim prompt non-interaktif
+- `--prompt-file <file>` / `-f <file>` — Prompt dari file
+- `--headless` — Provisioning lalu exit (tanpa sesi SSH)
+- `--output json` — Output JSON terstruktur (butuh `--headless`)
+- `--model <id>` / `-m <id>` — Override model
+- `--dry-run` — Preview tanpa provisioning
+
+## Manajemen Instance
+
+```bash
+# List instance sebelumnya
+jelma list
+jelma list --json
+
+# Jalankan ulang sesi terakhir
+jelma last
+
+# Hapus server cloud
+jelma delete
+jelma delete -c hetzner
+jelma delete --name jelma-abc --yes  # Hapus headless
+
+# Cek status live
+jelma status
+jelma status --prune  # Hapus server yang sudah gone
+
+# Jalankan ulang setup agent di VM yang ada
+jelma fix
+jelma fix <jelma-id>
+```
+
+## Optimisasi Kecepatan
+
+```bash
+# Fast mode — parallel boot + tarball + skip cloud-init
+jelma claude hetzner --fast
+
+# Fitur beta individual
+jelma claude gcp --beta tarball --beta parallel
+jelma openclaw local --beta sandbox  # Docker sandbox
+```
+
+| Fitur | Deskripsi |
+|-------|-----------|
+| `tarball` | Install dari tarball pre-built (skip npm live) |
+| `images` | Image/snapshot cloud pre-built |
+| `parallel` | Boot server + prompt setup paralel |
+| `recursive` | Install jelma di VM untuk spawn nested |
+| `sandbox` | Jalankan agent lokal di container Docker |
+
+## Jelma Rekursif
+
+Biarkan VM yang di-spawn membuat child VM sendiri:
+
+```bash
+jelma claude hetzner --beta recursive
+```
+
+Lihat spawn tree:
+```bash
+jelma tree
+# jelma-abc  Claude Code / Hetzner  2m lalu
+#   ├─ jelma-def  Codex CLI / Hetzner  1m lalu
+#   └─ jelma-ghi  OpenClaw / Hetzner  30d lalu
+```
+
+## File Config
+
+Load opsi dari file JSON:
+
+```json
+{
+  "model": "my-coder",
+  "steps": ["github", "browser"],
+  "name": "my-dev-box",
+  "setup": {
+    "github_token": "ghp_xxxx"
+  }
+}
+```
+
+```bash
+jelma codex gcp --config setup.json --headless --output json
+```
+
+## Tanpa CLI
+
+Setiap kombinasi bisa jalan sebagai one-liner mandiri:
+
+```bash
+bash <(curl -fsSL https://cli.neosantara.xyz/sh/{cloud}/{agent}.sh)
+```

--- a/index.mdx
+++ b/index.mdx
@@ -56,11 +56,19 @@ mode: "custom"
           </div>
         </a>
 
-        <a href="/api-reference/models/list-available-models" className="neo-map-row">
+        <a href="/en/coding-plan/overview" className="neo-map-row">
           <span>03</span>
           <div>
+            <strong>Coding Plan</strong>
+            <p>Subscribe for prompt-based access in your coding agent.</p>
+          </div>
+        </a>
+
+        <a href="/api-reference/models/list-available-models" className="neo-map-row">
+          <span>04</span>
+          <div>
             <strong>API reference</strong>
-            <p>Use generated endpoint docs from the backend spec.</p>
+            <p>Browse endpoint schemas and try requests live.</p>
           </div>
         </a>
       </div>
@@ -69,20 +77,20 @@ mode: "custom"
     <section className="neo-section">
       <div className="neo-section-head">
         <p>Choose a path</p>
-        <h2>Use Neosantara from the surface that fits how you build.</h2>
+        <h2>Five ways to build with Neosantara.</h2>
       </div>
 
       <div className="neo-path-grid">
         <a href="/en/quickstart" className="neo-path-card">
           <Icon icon="terminal" size={18} />
-          <h3>OpenAI-compatible API</h3>
-          <p>Use `/v1/chat/completions`, `/v1/responses`, embeddings, images, audio, files, and more with familiar client patterns.</p>
+          <h3>Chat & multimodal API</h3>
+          <p>Send chat, embeddings, image, audio, and file requests with SDKs you already know.</p>
         </a>
 
         <a href="/en/coding-plan/overview" className="neo-path-card">
           <Icon icon="code-branch" size={18} />
           <h3>Coding Plan</h3>
-          <p>Flat-fee, prompt-based quota for AI coding agents like Claude Code, Cline, and Jelma — no per-token billing, no overage.</p>
+          <p>Flat-fee prompt quota for Claude Code, Cline, and Jelma — no per-token billing.</p>
         </a>
 
         <a href="/en/integrations" className="neo-path-card">
@@ -108,7 +116,7 @@ mode: "custom"
     <section className="neo-section neo-spotlight-section">
       <div className="neo-section-head">
         <p>Integration spotlight</p>
-        <h2>Native paths are available when you need them.</h2>
+        <h2>Two native integrations, ready to use.</h2>
       </div>
 
       <div className="neo-spotlight-grid">
@@ -118,7 +126,10 @@ mode: "custom"
             <h3>Agno native</h3>
           </div>
           <p>Use `agno.models.neosantara.Neosantara` for multimodal agents, streaming, tools, and model switching.</p>
-          <strong>Open Agno guide -></strong>
+          <strong>
+            Open Agno guide
+            <Icon icon="arrow-right" size={12} />
+          </strong>
         </a>
 
         <a href="/en/any-llm" className="neo-spotlight-card">
@@ -127,7 +138,10 @@ mode: "custom"
             <h3>Any-LLM native</h3>
           </div>
           <p>Use provider id `neosantara` with `NEOSANTARA_API_KEY` for chat completions, Responses, images, and batch workflows.</p>
-          <strong>Open Any-LLM guide -></strong>
+          <strong>
+            Open Any-LLM guide
+            <Icon icon="arrow-right" size={12} />
+          </strong>
         </a>
       </div>
     </section>
@@ -143,7 +157,7 @@ mode: "custom"
           <div className="neo-code-title-row">
             <div>
               <p>OpenAI-compatible request</p>
-              <h2>Call a model with your API key.</h2>
+              <h3>Call a model with your API key.</h3>
             </div>
             <Icon icon="send" />
           </div>

--- a/index.mdx
+++ b/index.mdx
@@ -15,11 +15,11 @@ mode: "custom"
         </div>
 
         <h1 className="neo-doc-title">
-          Build with Neosantara.
+          One gateway. Every model.
         </h1>
 
         <p className="neo-doc-lead">
-          Find the model you need, call it through OpenAI-compatible endpoints, and use framework integrations when your app needs agents, tools, or provider-agnostic switching.
+          Neosantara is a unified AI gateway: call 100+ models — GPT, Claude, Gemini, and more — through one API key and OpenAI-compatible endpoints. Building with an AI coding agent instead? Subscribe to the Coding Plan for flat-fee, prompt-based access in Claude Code, Cline, or Jelma.
         </p>
 
         <div className="neo-actions">
@@ -69,7 +69,7 @@ mode: "custom"
     <section className="neo-section">
       <div className="neo-section-head">
         <p>Choose a path</p>
-        <h2>Use Neosantara from the surface that fits your app.</h2>
+        <h2>Use Neosantara from the surface that fits how you build.</h2>
       </div>
 
       <div className="neo-path-grid">
@@ -77,6 +77,12 @@ mode: "custom"
           <Icon icon="terminal" size={18} />
           <h3>OpenAI-compatible API</h3>
           <p>Use `/v1/chat/completions`, `/v1/responses`, embeddings, images, audio, files, and more with familiar client patterns.</p>
+        </a>
+
+        <a href="/en/coding-plan/overview" className="neo-path-card">
+          <Icon icon="code-branch" size={18} />
+          <h3>Coding Plan</h3>
+          <p>Flat-fee, prompt-based quota for AI coding agents like Claude Code, Cline, and Jelma — no per-token billing, no overage.</p>
         </a>
 
         <a href="/en/integrations" className="neo-path-card">

--- a/index.mdx
+++ b/index.mdx
@@ -98,7 +98,7 @@ mode: "custom"
         </a>
 
         <a href="/en/api-introduction" className="neo-path-card">
-          <Icon icon="braces" size={18} />
+          <Icon icon="brackets-curly" size={18} />
           <h3>Endpoint reference</h3>
           <p>Jump into generated request schemas, parameters, response bodies, and playground examples.</p>
         </a>

--- a/snippets/model-cards.jsx
+++ b/snippets/model-cards.jsx
@@ -1,3 +1,15 @@
+// ponytail: module-level cache so multiple <ModelCards> mounts on one page
+// share a single fetch instead of duplicating the network call. Ceiling: cache
+// never invalidates/expires for the page's lifetime -- fine since pricing data
+// doesn't change mid-session; a hard refresh re-fetches.
+let pricingDataPromise = null;
+function getPricingData() {
+  if (!pricingDataPromise) {
+    pricingDataPromise = fetch('https://api.neosantara.xyz/v1/public/pricing').then(res => res.json());
+  }
+  return pricingDataPromise;
+}
+
 export const ModelCards = ({ capability }) => {
   const [models, setModels] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -5,8 +17,7 @@ export const ModelCards = ({ capability }) => {
   const [copiedId, setCopiedId] = useState(null);
 
   useEffect(() => {
-    fetch('https://api.neosantara.xyz/v1/public/pricing')
-      .then(res => res.json())
+    getPricingData()
       .then(json => {
         if (json.data) {
           // Filter model berdasarkan capability yang diminta
@@ -19,6 +30,7 @@ export const ModelCards = ({ capability }) => {
       })
       .catch(err => {
         console.error('Failed to fetch pricing:', err);
+        pricingDataPromise = null; // allow retry on next mount instead of caching the failure forever
         setLoading(false);
       });
   }, [capability]);

--- a/snippets/model-cards.jsx
+++ b/snippets/model-cards.jsx
@@ -30,7 +30,7 @@ export const ModelCards = ({ capability }) => {
   };
 
   if (loading) return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6" role="status" aria-label="Loading models" aria-busy="true">
       {[1, 2, 3, 4, 5, 6].map(i => (
         <div key={i} className="border border-gray-200 dark:border-gray-800 rounded-xl p-4 bg-gray-50/50 dark:bg-white/5 animate-pulse h-32"></div>
       ))}
@@ -58,12 +58,12 @@ export const ModelCards = ({ capability }) => {
                   <button 
                     onClick={() => handleCopy(model.name)}
                     className="neo-icon-action p-1 rounded transition-colors text-gray-400"
-                    title="Copy Model ID"
+                    aria-label="Copy Model ID"
                   >
                     {copiedId === model.name ? (
-                      <svg className="w-3.5 h-3.5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7"></path></svg>
+                      <svg className="w-3.5 h-3.5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7"></path></svg>
                     ) : (
-                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>
+                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>
                     )}
                   </button>
                 </div>
@@ -90,6 +90,7 @@ export const ModelCards = ({ capability }) => {
           <button 
             onClick={() => setIsExpanded(!isExpanded)}
             className="neo-secondary-action text-xs font-bold uppercase tracking-widest text-gray-500 transition-colors py-2 px-4 border border-gray-200 dark:border-gray-800 rounded-full bg-gray-50/50 dark:bg-white/5"
+            aria-expanded={isExpanded}
           >
             {isExpanded ? 'Show Less' : `Show All (${models.length})`}
           </button>

--- a/snippets/model-grid.jsx
+++ b/snippets/model-grid.jsx
@@ -156,6 +156,7 @@ export const ModelGrid = () => {
             key={index}
             className="neo-model-card rounded-xl bg-white dark:bg-[#13171B] border border-[#d9e1ec] dark:border-gray-700 overflow-hidden px-4 py-3 flex flex-row gap-0 justify-between no-underline transition-all duration-200"
             style={getGridStyle(index)}
+            aria-label={group.title}
           >
             <div className={"flex items-start flex-col " + (group.hasViewAll ? "justify-between" : "justify-center")}>
               <h3 className="text-base text-left text-[#171a1e] dark:text-white font-bold m-0 leading-[24px]">
@@ -167,7 +168,7 @@ export const ModelGrid = () => {
                     <p className="text-xs font-semibold text-neutral-500 dark:text-gray-400 mr-2 whitespace-nowrap uppercase tracking-wider">
                       View all
                     </p>
-                    <svg width={5} height={8} viewBox="0 0 5 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <svg width={5} height={8} viewBox="0 0 5 8" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                       <path d="M1 1L4 4L1 7" stroke="currentColor" strokeLinecap="round" />
                     </svg>
                   </div>
@@ -197,7 +198,7 @@ export const ModelGrid = () => {
               </div>
 
               {!group.hasViewAll && (
-                <svg width={5} height={8} viewBox="0 0 5 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <svg width={5} height={8} viewBox="0 0 5 8" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                   <path d="M0.930237 1.11548L4.06977 4.00009L0.930237 6.88471" stroke="currentColor" strokeLinecap="round" />
                 </svg>
               )}

--- a/snippets/model-info.jsx
+++ b/snippets/model-info.jsx
@@ -80,7 +80,7 @@ export const ModelInfo = ({
                 }
               }}
               className="ml-1 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-              title="Copy Model ID"
+              aria-label="Copy Model ID"
             >
               <Icon icon="copy" size={14} />
             </button>
@@ -150,7 +150,7 @@ export const ModelInfo = ({
             
             <div className="rounded-lg p-4 bg-zinc-50 dark:bg-zinc-900/30 border border-zinc-100 dark:border-zinc-800/50">
               <div className="flex items-center gap-2 mb-2">
-                <div className="w-1.5 h-1.5 rounded-full bg-emerald-500"></div>
+                <div className="w-1.5 h-1.5 rounded-full bg-emerald-500" aria-hidden="true"></div>
                 <span className="text-xs font-semibold text-zinc-900 dark:text-white">New Account Benefit</span>
               </div>
               <p className="text-xs text-zinc-600 dark:text-zinc-400 mb-3 leading-relaxed">

--- a/style.css
+++ b/style.css
@@ -737,7 +737,8 @@ article table th,
 }
 
 .neo-card-head h2,
-.neo-code-title-row h2 {
+.neo-code-title-row h2,
+.neo-code-title-row h3 {
   margin: 0.75rem 0 0;
   color: var(--neo-fg) !important;
   font-family: var(--neo-font-mono) !important;
@@ -773,7 +774,8 @@ article table th,
   padding: 1.5rem;
 }
 
-.neo-code-title-row h2 {
+.neo-code-title-row h2,
+.neo-code-title-row h3 {
   font-size: 1.25rem;
 }
 
@@ -849,7 +851,8 @@ article table th,
     flex-direction: column;
   }
 
-  .neo-code-title-row h2 {
+  .neo-code-title-row h2,
+  .neo-code-title-row h3 {
     font-size: 1.05rem;
   }
 

--- a/style.css
+++ b/style.css
@@ -798,7 +798,10 @@ article table th,
     font-size: 1.06rem;
   }
 
-  .neo-path-grid,
+  .neo-path-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .neo-link-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -823,7 +826,7 @@ article table th,
   }
 
   .neo-path-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -394,10 +394,6 @@ article table th,
   text-align: center;
 }
 
-#pagination {
-  display: none;
-}
-
 .home-page ~ :is(.callout, [data-callout-type]) {
   display: none !important;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded Coding Plan docs and improved Jelma and Model Routes guidance. Adds a canonical Quota & Limits page, introduces a Learning Path hub, and documents the `--model` flag with a default `garda-core` route for smoother setup.

- **New Features**
  - Coding Plan docs (EN/ID): Overview, Quick Start, Learning Path hub, and a single-source Quota & Limits; all pages now point to the canonical quota reference.
  - Learning Resources subgroup (EN/ID): Best Practice and Memory Mechanism, vendor‑neutral.
  - Jelma guides (EN/ID): Overview, Usage, Command Reference, Best Practices, FAQ; documents `--model` usage, `jelma models`, and defaults to `garda-core` when unset.
  - Model Routes docs (EN/ID): Virtual aliases with fallback chains, dashboard-only management, usage examples in tools and Jelma.
  - Updated rate-limit tables (EN/ID) and homepage copy; added a Coding Plan path card and navigation entries.

- **Bug Fixes**
  - Restored previous/next pagination (removed CSS that hid `#pagination`) and reverted theme change.
  - A11y: added aria labels/expanded states and hid decorative elements in model components.
  - Perf: cached public pricing fetch across `ModelCards` mounts.
  - Content fixes: removed deprecated model reference, corrected icon name, clarified Model Routes as dashboard-only, and added concurrency limits to FAQ.

<sup>Written for commit 0f95dcbef1e2f18d22351829e5c8168e534c523e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ErRickow/docs/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Coding Plan** documentation hub in English and Indonesian, including guides for quotas, model switching, tool integration, usage policy, and model routes.
  * Added new **Jelma** and coding workflow pages, plus a clearer home page path to key docs.

* **Bug Fixes**
  * Updated rate limit values across subscription tiers.
  * Improved documentation navigation structure for both locales.

* **Style**
  * Enhanced page responsiveness and code title styling.
  * Improved accessibility for model cards and copy actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->